### PR TITLE
PVAYLADEV-685 System parameter for deactivating periodic OCSP-response retrieval 

### DIFF
--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -25,7 +25,7 @@ Doc. ID: UG-SYSPAR
 | 01.12.2017 | 2.13       | Added documentation for minimum global conf version | Sami Kallio |
 | 20.01.2017 | 2.14       | Added license text and version history | Sami Kallio |
 | 08.02.2017 | 2.15       | Updated documentation with new environmental monitoring parameters describing sensor intervals | Sami Kallio |
-
+| 23.02.2017 | 2.16       | Added documentation for OCSP-response retrieval deactivation parameter | Tatu Repo |
 
 
 ## Table of Contents
@@ -246,6 +246,7 @@ For instructions on how to change the parameter values, see section [Changing th
 | center               | internal-directory      | internalconf             | Name of the signed internal configuration directory that is distributed to the configuration clients (security servers and/or configuration proxies) of this X-Road instance.                |
 | center               | trusted-anchors-allowed | false                    | True if federation is allowed for this X-Road instance.                                                                                                                                      |
 | center               | minimum-global-configuration-version | 2                    | Minimum supported global configuration version on central server. Change this if old global configuration versions need to be supported.                                                                                                                                       |
+| signer               | ocsp-response-retrieval-active | false <br/> _(see Description for more information)_               | This property is used as an override to deactivate periodic OCSP-response retrieval for components that don't need that functionality, but still use signer. <br/><br/> Values: <br/> `false` - OCSP-response retrieval jobs are never scheduled <br/> `true` - periodic OCSP-response retrieval is active based on ocspFetchInterval. **Note that if the entire property is missing, it is interpreted as true.** <br/><br/>  This property is delivered as an override and only for the components where the OCSP-response retrieval jobs need to be deactivated. The property is missing for components that require OCSP-response retrieval to be activated.|
 
 System Parameters in the Database
 ---------------------------------------------------------------------------------------------------------------------------------------------
@@ -291,7 +292,7 @@ This chapter describes the system parameters used by the X-Road configuration pr
 | configuration-proxy  | hash-algorithm-uri     | http://www.w3.org/2001/04/xmlenc#sha512                      | URI that identifies the algorithm the configuration proxy uses when calculating hash values for the global configuration files.<br/>The possible values are<br/>http://www.w3.org/2001/04/xmlenc#sha256,<br/>http://www.w3.org/2001/04/xmlenc#sha512                                                                                                                   |
 | configuration-proxy  | download-script        | /usr/share/xroad/scripts/download\_instance\_configuration.sh | Absolute path to the location of the script that initializes the global configuration download procedure.                                                     |
 | configuration-proxy               | minimum-global-configuration-version | 2                    | Minimum supported global configuration version on configuration proxy. Change this if old global configuration versions need to be supported.                                                                                                                                       |
-
+| signer               | ocsp-response-retrieval-active | false <br/> _(see Description for more information)_               | This property is used as an override to deactivate periodic OCSP-response retrieval for components that don't need that functionality, but still use signer. <br/><br/> Values: <br/> `false` - OCSP-response retrieval jobs are never scheduled <br/> `true` - periodic OCSP-response retrieval is active based on ocspFetchInterval. **Note that if the entire property is missing, it is interpreted as true.** <br/><br/>  This property is delivered as an override and only for the components where the OCSP-response retrieval jobs need to be deactivated. The property is missing for components that require OCSP-response retrieval to be activated.|
 
 [1] See also [*http://www.quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger*](http://www.quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger).
 

--- a/src/common-util/src/main/java/ee/ria/xroad/common/SystemProperties.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/SystemProperties.java
@@ -274,6 +274,9 @@ public final class SystemProperties {
     public static final String SIGNER_CSR_SIGNATURE_ALGORITHM =
             PREFIX + "signer.csr-signature-algorithm";
 
+    public static final String OCSP_RESPONSE_RETRIEVAL_ACTIVE =
+            PREFIX + "signer.ocsp-response-retrieval-active";
+
     // AntiDos ----------------------------------------------------------------
 
     /** Property name of the AntiDos on/off switch */
@@ -734,6 +737,14 @@ public final class SystemProperties {
      */
     public static String getSignerCsrSignatureAlgorithm() {
         return System.getProperty(SIGNER_CSR_SIGNATURE_ALGORITHM, getDefaultSignatureAlgorithm());
+    }
+
+    /**
+     * @return whether OCSP-response retrieval loop should be activated
+     */
+    public static boolean isOcspResponseRetrievalActive() {
+        return "true".equalsIgnoreCase(
+                System.getProperty(OCSP_RESPONSE_RETRIEVAL_ACTIVE, "true"));
     }
 
     /**

--- a/src/packages/default-configuration/override-signer.ini
+++ b/src/packages/default-configuration/override-signer.ini
@@ -1,0 +1,7 @@
+; this file is used to deploy package-specific configurations for signer, e.g. turning off OCSP-response retrieval
+; for signers in configuration proxy or central server
+[signer]
+
+; property to define whether OCSP-response retrieval is active (default true)
+ocsp-response-retrieval-active=false
+

--- a/src/packages/xroad/debian/xroad-center.install
+++ b/src/packages/xroad/debian/xroad-center.install
@@ -1,6 +1,7 @@
 center/usr/* usr/ 
 center/etc/* etc/
 ../default-configuration/center.ini etc/xroad/conf.d
+../default-configuration/override-signer.ini etc/xroad/conf.d
 ../default-configuration/managementservices.wsdl var/lib/xroad/public
 ../default-configuration/rsyslog.d/* etc/rsyslog.d/
 ../default-configuration/center-ui-jetty-logback-context-name.xml etc/xroad/conf.d

--- a/src/packages/xroad/debian/xroad-confproxy.install
+++ b/src/packages/xroad/debian/xroad-confproxy.install
@@ -2,6 +2,7 @@ confproxy/etc/* etc/
 ../../configuration-proxy/scripts/* usr/share/xroad/scripts
 ../../configuration-proxy/build/libs/configuration-proxy-1.0.jar usr/share/xroad/jlib/
 ../default-configuration/confproxy.ini etc/xroad/conf.d
+../default-configuration/override-signer.ini etc/xroad/conf.d
 ../default-configuration/confproxy-logback.xml etc/xroad/conf.d
 ../../configuration-proxy-LICENSE.info usr/share/doc/xroad-confproxy
 

--- a/src/packages/xroad/debian/xroad-confproxy.postinst
+++ b/src/packages/xroad/debian/xroad-confproxy.postinst
@@ -33,6 +33,7 @@ esac
 #DEBHELPER#
 
 invoke-rc.d nginx restart
+invoke-rc.d xroad-signer restart
 
 # disable confclient start
 echo manual > /etc/init/xroad-confclient.override

--- a/src/signer/src/main/java/ee/ria/xroad/signer/OcspClientJob.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/OcspClientJob.java
@@ -23,10 +23,8 @@
 package ee.ria.xroad.signer;
 
 import ee.ria.xroad.signer.certmanager.OcspClientWorker;
-import ee.ria.xroad.signer.util.VariableIntervalPeriodicJob;
 import lombok.extern.slf4j.Slf4j;
 import scala.concurrent.duration.FiniteDuration;
-
 import java.util.concurrent.TimeUnit;
 
 import static ee.ria.xroad.signer.certmanager.OcspClientWorker.GLOBAL_CONF_INVALIDATED;
@@ -38,7 +36,7 @@ import static ee.ria.xroad.signer.protocol.ComponentNames.OCSP_CLIENT;
  * based on the status of the last refresh.
  */
 @Slf4j
-public class OcspClientJob extends VariableIntervalPeriodicJob {
+public class OcspClientJob extends OcspRetrievalJob {
 
     public static final String CANCEL = "Cancel";
     public static final String FAILED = "Failed";


### PR DESCRIPTION
Added a system parameter that is delivered as an override in confproxy and center packages. It is used to disable the automatic scheduling of OCSP-response retrieval jobs in the actor preStart method. 