### PR TITLE
PVAYLADEV-726: Add explicit UTF8 encoding to diagnostics response

### DIFF
--- a/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
@@ -35,6 +35,7 @@ import ee.ria.xroad.signer.certmanager.OcspClientWorker;
 import ee.ria.xroad.signer.util.SignerUtil;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static ee.ria.xroad.common.SystemProperties.CONF_FILE_PROXY;
@@ -60,6 +61,8 @@ public final class SignerMain {
     private static Signer signer;
     private static AdminPort adminPort;
     private static CertificationServiceDiagnostics diagnosticsDefault;
+
+    private static boolean diagnosticsBusy = false;
 
     private SignerMain() {
     }
@@ -149,7 +152,9 @@ public final class SignerMain {
                     diagnostics = diagnosticsDefault;
                 }
                 try {
-                    JsonUtils.getSerializer().toJson(diagnostics, getParams().response.getWriter());
+                    HttpServletResponse response = getParams().response;
+                    response.setCharacterEncoding("UTF8");
+                    JsonUtils.getSerializer().toJson(diagnostics, response.getWriter());
                 } catch (IOException e) {
                     log.error("Error writing response {}", e);
                 }

--- a/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
@@ -62,8 +62,6 @@ public final class SignerMain {
     private static AdminPort adminPort;
     private static CertificationServiceDiagnostics diagnosticsDefault;
 
-    private static boolean diagnosticsBusy = false;
-
     private SignerMain() {
     }
 


### PR DESCRIPTION
Added explicit UTF-8 encoding to the response that provides the writer for JSON-data in admin port status request handler.