### PR TITLE
PVAYLADEV-738: Fixed concurrency issue in AdminPort synchronous request handling

### DIFF
--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientMain.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientMain.java
@@ -40,6 +40,8 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobListener;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalTime;
@@ -277,7 +279,7 @@ public final class ConfigurationClientMain {
 
         adminPort.addHandler("/execute", new AdminPort.SynchronousCallback() {
             @Override
-            public void run() {
+            public void handle(HttpServletRequest request, HttpServletResponse response) {
                 log.info("handler /execute");
                 try {
                     client.execute();
@@ -289,10 +291,11 @@ public final class ConfigurationClientMain {
 
         adminPort.addHandler("/status", new AdminPort.SynchronousCallback() {
             @Override
-            public void run() {
+            public void handle(HttpServletRequest request, HttpServletResponse response) {
                 try {
                     log.info("handler /status");
-                    JsonUtils.getSerializer().toJson(listener.getStatus(), getParams().response.getWriter());
+                    response.setCharacterEncoding("UTF8");
+                    JsonUtils.getSerializer().toJson(ConfigurationClientJobListener.getStatus(), response.getWriter());
                 } catch (Exception e) {
                     log.error("Error getting conf client status", e);
                 }

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
@@ -48,6 +48,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import scala.concurrent.Await;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
@@ -214,7 +216,7 @@ public final class ProxyMain {
          */
         adminPort.addHandler("/timestampstatus", new AdminPort.SynchronousCallback() {
             @Override
-            public void run() {
+            public void handle(HttpServletRequest request, HttpServletResponse response) {
                 try {
                     log.info("/timestampstatus");
 
@@ -252,8 +254,8 @@ public final class ProxyMain {
                         }
                     }
 
-
-                    JsonUtils.getSerializer().toJson(result, getParams().response.getWriter());
+                    response.setCharacterEncoding("UTF8");
+                    JsonUtils.getSerializer().toJson(result, response.getWriter());
 
                 } catch (Exception e) {
                     log.error("Error getting timeout status", e);

--- a/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
@@ -35,6 +35,7 @@ import ee.ria.xroad.signer.certmanager.OcspClientWorker;
 import ee.ria.xroad.signer.util.SignerUtil;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
@@ -125,7 +126,7 @@ public final class SignerMain {
 
         port.addHandler("/execute", new AdminPort.SynchronousCallback() {
             @Override
-            public void run() {
+            public void handle(HttpServletRequest request, HttpServletResponse response) {
                 try {
                     signer.execute();
                 } catch (Exception ex) {
@@ -136,7 +137,7 @@ public final class SignerMain {
 
         port.addHandler("/status", new AdminPort.SynchronousCallback() {
             @Override
-            public void run() {
+            public void handle(HttpServletRequest request, HttpServletResponse response) {
                 log.info("handler /status");
                 CertificationServiceDiagnostics diagnostics = null;
                 try {
@@ -153,7 +154,6 @@ public final class SignerMain {
                     diagnostics = diagnosticsDefault;
                 }
                 try {
-                    HttpServletResponse response = getParams().response;
                     response.setCharacterEncoding("UTF8");
                     JsonUtils.getSerializer().toJson(diagnostics, response.getWriter());
                 } catch (IOException e) {


### PR DESCRIPTION
A problem in diagnostics view initialization revealed concurrency issues in AdminPort request handling. AdminPort request handling implementation was discovered to not be thread-safe and it was possible for two overlapping requests to interfere with each other's parameters. This caused two overlapping requests for diagnostics information to fail causing the diagnostics view to display errors.

The AdminPort synchronous request handling was refactored to use parameters in a thread-safe manner while the unused and unsafe asynchronous request handling was removed entirely. The asynchronous handling should be implemented when there is an actual use case for it. 