### PR TITLE
PVAYLADEV-795

### DIFF
--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/InternalSslSocketFactory.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/InternalSslSocketFactory.java
@@ -1,0 +1,93 @@
+/**
+ * The MIT License
+ * Copyright (c) 2015 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ee.ria.xroad.proxy.clientproxy;
+
+import ee.ria.xroad.common.conf.InternalSSLKey;
+import ee.ria.xroad.common.conf.serverconf.ServerConf;
+import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.proxy.util.InternalKeyManager;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ *  Holds an SSL socket factory that only trusts the internal certificate
+ *  and presents the internal cert when connecting
+ */
+final class InternalSslSocketFactory {
+
+    private static volatile SSLSocketFactory sslSocketFactory;
+    private static Object lock = new Object();
+
+    private InternalSslSocketFactory() { }
+
+    static SSLSocketFactory getInstance() throws Exception {
+        if (sslSocketFactory == null) {
+            synchronized (lock) {
+                if (sslSocketFactory == null) {
+                    final InternalSSLKey sslKey = ServerConf.getSSLKey();
+                    SSLContext sslContext = SSLContext.getInstance(CryptoUtils.SSL_PROTOCOL);
+                    sslContext.init(
+                            new KeyManager[]{new InternalKeyManager(sslKey)},
+                            new TrustManager[]{new InternalTrustManager(sslKey.getCert())},
+                            new SecureRandom());
+                    sslSocketFactory = sslContext.getSocketFactory();
+                }
+            }
+        }
+        return sslSocketFactory;
+    }
+
+    static final class InternalTrustManager implements X509TrustManager {
+
+        private final X509Certificate internalCert;
+
+        private InternalTrustManager(X509Certificate internalCert) {
+            this.internalCert = internalCert;
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            //nop
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            if (chain == null || chain.length == 0 || !internalCert.equals(chain[0])) {
+                throw new CertificateException("Not trusted");
+            }
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+
+}

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/WsdlRequestProcessor.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/WsdlRequestProcessor.java
@@ -29,7 +29,14 @@ import ee.ria.xroad.common.conf.serverconf.ServerConf;
 import ee.ria.xroad.common.identifier.CentralServiceId;
 import ee.ria.xroad.common.identifier.ClientId;
 import ee.ria.xroad.common.identifier.ServiceId;
-import ee.ria.xroad.common.message.*;
+import ee.ria.xroad.common.message.JaxbUtils;
+import ee.ria.xroad.common.message.ProtocolVersion;
+import ee.ria.xroad.common.message.SoapBuilder;
+import ee.ria.xroad.common.message.SoapFault;
+import ee.ria.xroad.common.message.SoapHeader;
+import ee.ria.xroad.common.message.SoapMessage;
+import ee.ria.xroad.common.message.SoapMessageDecoder;
+import ee.ria.xroad.common.message.SoapMessageImpl;
 import ee.ria.xroad.common.util.HttpHeaders;
 import ee.ria.xroad.common.util.MimeTypes;
 import ee.ria.xroad.common.util.MimeUtils;
@@ -37,7 +44,9 @@ import ee.ria.xroad.proxy.common.WsdlRequestData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 
+import javax.net.ssl.HttpsURLConnection;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.bind.Marshaller;
@@ -153,29 +162,41 @@ public class WsdlRequestProcessor {
         }
     }
 
-    // package-private for unit-test purposes
     HttpURLConnection createConnection(SoapMessageImpl message) throws Exception {
-        URL url = new URL("http://127.0.0.1:" + SystemProperties.getClientProxyHttpPort());
 
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
-        con.setDoInput(true);
-        con.setDoOutput(true);
-        // Use the same timeouts as client proxy to server proxy connections.
-        con.setConnectTimeout(SystemProperties.getClientProxyTimeout());
-        con.setReadTimeout(SystemProperties.getClientProxyHttpClientTimeout());
-        con.setRequestMethod("POST");
+        final URL url;
+        final HttpURLConnection urlConnection;
 
-        con.setRequestProperty(HttpHeaders.CONTENT_TYPE, MimeUtils.contentTypeWithCharset(MimeTypes.TEXT_XML,
-                StandardCharsets.UTF_8.name()));
-
-        IOUtils.write(message.getBytes(), con.getOutputStream());
-
-        if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
-            throw new RuntimeException("Received HTTP error: " + con.getResponseCode() + " - "
-                    + con.getResponseMessage());
+        if (request.isSecure()) {
+            url = new URL("https://127.0.0.1:" + SystemProperties.getClientProxyHttpsPort());
+            HttpsURLConnection tmp = (HttpsURLConnection) url.openConnection();
+            tmp.setSSLSocketFactory(InternalSslSocketFactory.getInstance());
+            tmp.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+            urlConnection = tmp;
+        } else {
+            url = new URL("http://127.0.0.1:" + SystemProperties.getClientProxyHttpPort());
+            urlConnection = (HttpURLConnection) url.openConnection();
         }
 
-        return con;
+        urlConnection.setDoInput(true);
+        urlConnection.setDoOutput(true);
+        // Use the same timeouts as client proxy to server proxy connections.
+        urlConnection.setConnectTimeout(SystemProperties.getClientProxyTimeout());
+        urlConnection.setReadTimeout(SystemProperties.getClientProxyHttpClientTimeout());
+        urlConnection.setRequestMethod("POST");
+
+        urlConnection.setRequestProperty(HttpHeaders.CONTENT_TYPE, MimeUtils.contentTypeWithCharset(MimeTypes.TEXT_XML,
+                StandardCharsets.UTF_8.name()));
+
+        IOUtils.write(message.getBytes(), urlConnection.getOutputStream());
+
+        if (urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+            urlConnection.disconnect();
+            throw new RuntimeException("Received HTTP error: " + urlConnection.getResponseCode() + " - "
+                    + urlConnection.getResponseMessage());
+        }
+
+        return urlConnection;
     }
 
     private class SoapDecoderCallback implements SoapMessageDecoder.Callback {

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
@@ -176,7 +176,7 @@ public final class ProxyMain {
         log.trace("shutdown()");
 
         stopServices();
-        actorSystem.shutdown();
+        actorSystem.terminate();
     }
 
     private static void createServices() throws Exception {

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/HttpClientCreator.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/HttpClientCreator.java
@@ -27,6 +27,7 @@ import java.security.SecureRandom;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
+import ee.ria.xroad.proxy.util.InternalKeyManager;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -159,7 +160,7 @@ public class HttpClientCreator {
         InternalSSLKey key = ServerConf.getSSLKey();
 
         if (key != null) {
-            return new KeyManager[]{new ServiceKeyManager(key)};
+            return new KeyManager[]{new InternalKeyManager(key)};
         }
 
         return null;

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/InternalKeyManager.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/InternalKeyManager.java
@@ -20,28 +20,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package ee.ria.xroad.proxy.serverproxy;
+package ee.ria.xroad.proxy.util;
 
+import ee.ria.xroad.common.conf.InternalSSLKey;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedKeyManager;
 import java.net.Socket;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.X509ExtendedKeyManager;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import ee.ria.xroad.common.conf.InternalSSLKey;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
-class ServiceKeyManager extends X509ExtendedKeyManager {
+/**
+ * a KeyManager that holds the internal SSL Key
+ */
+@RequiredArgsConstructor
+public class InternalKeyManager extends X509ExtendedKeyManager {
 
     private static final Logger LOG =
-            LoggerFactory.getLogger(ServiceKeyManager.class);
+            LoggerFactory.getLogger(InternalKeyManager.class);
 
     private static final String ALIAS = "AuthKeyManager";
 

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/IsAuthentication.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/IsAuthentication.java
@@ -22,16 +22,15 @@
  */
 package ee.ria.xroad.common.conf.serverconf;
 
-import static ee.ria.xroad.common.ErrorCodes.X_INTERNAL_ERROR;
-import static ee.ria.xroad.common.ErrorCodes.X_SSL_AUTH_FAILED;
+import ee.ria.xroad.common.CodedException;
+import ee.ria.xroad.common.identifier.ClientId;
+import lombok.extern.slf4j.Slf4j;
 
 import java.security.cert.X509Certificate;
 import java.util.List;
 
-import ee.ria.xroad.common.CodedException;
-import ee.ria.xroad.common.conf.InternalSSLKey;
-import ee.ria.xroad.common.identifier.ClientId;
-import lombok.extern.slf4j.Slf4j;
+import static ee.ria.xroad.common.ErrorCodes.X_INTERNAL_ERROR;
+import static ee.ria.xroad.common.ErrorCodes.X_SSL_AUTH_FAILED;
 
 /**
  * Encapsulates the information system authentication method.
@@ -77,7 +76,7 @@ public enum IsAuthentication {
                                 + " TLS certificate", client);
             }
 
-            if (auth.getCert().equals(InternalSSLKey.load().getCert())) {
+            if (auth.getCert().equals(ServerConf.getSSLKey().getCert())) {
                 // do not check certificates for local TLS connections
                 return;
             }


### PR DESCRIPTION
Use https with internal TLS key and certificate in WsdlRequestProcessor when the client-side GET request uses https. Fixes a problem where requiring HTTPS on client connections causes the wsdl request to fail.
