### PR TITLE
PVAYLADEV-783: Diagnostics view breaks if a single section fails to resolve its status

### DIFF
--- a/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
+++ b/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
@@ -1505,15 +1505,24 @@ If it is absolutely necessary to restore the system from a backup made on a diff
 
 Open the **Management** menu and select **Diagnostics**.
 
-On this page you can examine the statuses of the following services.
+On this page you can examine the statuses of the following services:
 
  Service              | Status           | Message        | Previous Update          | Next Update
 --------------------- | ---------------- | -------------- | ------------------------ | ------------------------
  Global configuration | Green/yellow/red | Status message | The time of the global configuration client’s last run | The estimated time of the global configuration client’s next run
  Timestamping         | Green/yellow/red | Status message | The time of the last timestamping operation            | Not used                                   
+ OCSP-responders      | Green/yellow/red | Status message | The time of the last contact with the OCSP-responder   | The latest possible time for the next OCSP-refresh
+ 
+To refresh the service statuses click the **Diagnostics** item on the **Management** menu.
 
-To refresh the service statuses click again the **Diagnostics** item on the **Management** menu.
+The status colors indicate the following:
+- **Red indicator** – service cannot be contacted or is not operational
+- **Yellow indicator** – service has been contacted but is yet to have been used to verify its status
+- **Green indicator** – service has been successfully contacted and used to verify it is operational
 
+The status message offers more detailed information on the current status.
+
+If a section of the diagnostics view appears empty, it means that there either is no configured service available or that checking the service status has failed. If sections are empty, try refreshing the diagnostics view or check the service configuration.
 
 ## 15 Operational Monitoring
 

--- a/src/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsErrorCodes.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsErrorCodes.java
@@ -31,6 +31,7 @@ public final class DiagnosticsErrorCodes {
     }
 
     public static final int RETURN_SUCCESS = 0;
+    public static final int ERROR_CODE_LOGMANAGER_UNAVAILABLE = 132;
     public static final int ERROR_CODE_OCSP_UNINITIALIZED = 131;
     public static final int ERROR_CODE_OCSP_RESPONSE_INVALID = 130;
     public static final int ERROR_CODE_OCSP_CONNECTION_ERROR = 129;

--- a/src/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsStatus.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsStatus.java
@@ -25,7 +25,6 @@ package ee.ria.xroad.common;
 import java.io.Serializable;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.FormatStyle;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -37,7 +36,7 @@ import lombok.ToString;
 @Getter
 @ToString
 public class DiagnosticsStatus implements Serializable {
-    private static final FormatStyle FORMAT_STYLE = FormatStyle.SHORT;
+    public static final DateTimeFormatter DIAGNOSTICS_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     private int returnCode;
     private LocalTime prevUpdate;
     private LocalTime nextUpdate;
@@ -57,9 +56,9 @@ public class DiagnosticsStatus implements Serializable {
 
     /**
      *
-     * @param returnCode
-     * @param prevUpdate
-     * @param description
+     * @param returnCode return code
+     * @param prevUpdate previous update
+     * @param description status description
      */
     public DiagnosticsStatus(int returnCode, LocalTime prevUpdate, String description) {
         this.returnCode = returnCode;
@@ -108,7 +107,7 @@ public class DiagnosticsStatus implements Serializable {
         if (time == null) {
             return "";
         } else {
-            return time.format(DateTimeFormatter.ofLocalizedTime(FORMAT_STYLE));
+            return time.format(DIAGNOSTICS_FORMATTER);
         }
     }
 }

--- a/src/proxy-ui/app/views/diagnostics/index.html.erb
+++ b/src/proxy-ui/app/views/diagnostics/index.html.erb
@@ -42,10 +42,10 @@
           </thead>
           <tbody>
           <tr>
-            <td><i class="fa fa-circle <%= @globalConfStatusClass %>"></i></td>
-            <td><%= @globalConfStatusMessage %></td>
-            <td><%= @globalConfPrevUpdate %></td>
-            <td><%= @globalConfNextUpdate %></td>
+            <td><i class="fa fa-circle <%= @globalConfStatus[:status_class] %>"></i></td>
+            <td><%= @globalConfStatus[:status_message] %></td>
+            <td><%= @globalConfStatus[:prev_update] %></td>
+            <td><%= @globalConfStatus[:next_update] %></td>
           </tr>
           </tbody>
         </table>
@@ -70,7 +70,6 @@
                 <td><%= key %></td>
                 <td><%= get_status_message(status['returnCode']) %></td>
                 <td><%= get_formatted_time(status['prevUpdate']) %></td>
-
               </tr>
           <% end %>
           </tbody>

--- a/src/proxy-ui/app/views/diagnostics/index.html.erb
+++ b/src/proxy-ui/app/views/diagnostics/index.html.erb
@@ -42,10 +42,10 @@
           </thead>
           <tbody>
           <tr>
-            <td><i class="fa fa-circle <%= @globalConfStatus[:status_class] %>"></i></td>
-            <td><%= @globalConfStatus[:status_message] %></td>
-            <td><%= @globalConfStatus[:prev_update] %></td>
-            <td><%= @globalConfStatus[:next_update] %></td>
+            <td><i class="fa fa-circle <%= @global_conf_status[:status_class] %>"></i></td>
+            <td><%= @global_conf_status[:status_message] %></td>
+            <td><%= @global_conf_status[:prev_update] %></td>
+            <td><%= @global_conf_status[:next_update] %></td>
           </tr>
           </tbody>
         </table>

--- a/src/proxy-ui/config/locales/controllers_en.yml
+++ b/src/proxy-ui/config/locales/controllers_en.yml
@@ -20,7 +20,7 @@ en:
     error_code_cannot_download_conf: "Unable to download global configuration. Check network connection to global configuration provider."
     error_code_missing_private_params: "The downloaded global configuration did not contain private parameters."
     error_code_timestamp_request_timed_out: "Connection to the timestamp server timed out. Check the network connection to the timestamp server."
-    error_code_malformed_timestamp_server_url: "Malformed timestamp server ulr. Check the URL."
+    error_code_malformed_timestamp_server_url: "Malformed timestamp server URL. Check the URL."
     error_code_unknown: "Unknown error code."
     error_code_uninitialized: "The configuration client is initializing."
     error_code_timestamp_uninitialized: "Connection ok, no timestamp request made yet."
@@ -29,6 +29,7 @@ en:
     error_code_ocsp_failed: "Unable to fetch response from the OCSP responder."
     error_code_ocsp_response_invalid: "Unable to parse the OCSP response."
     error_code_ocsp_uninitialized: "Status request not sent yet."
+    error_code_logmanager_unavailable: "Unable to obtain message log timestamping status"
 
   init:
     not_authorized: "Fatal system error - contact system administrator"

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
@@ -58,6 +58,7 @@ import scala.concurrent.Await;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
@@ -231,31 +232,32 @@ public final class ProxyMain {
         /**
          * Diganostics for timestamping.
          * First check the connection to timestamp server. If OK, check the status of the previous timestamp request.
-         * If the previous request has failed or connection cannot be made, DiagnosticsStatus tells the reason.
+         * If the previous request has failed or connection cannot be made, DiagnosticsStatus tells the reason. If
+         * LogManager is unavailable, uses the connection check to produce a more informative status.
          */
         adminPort.addHandler("/timestampstatus", new AdminPort.SynchronousCallback() {
             @Override
             public void handle(HttpServletRequest request, HttpServletResponse response) {
+                log.info("/timestampstatus");
+
+                Map<String, DiagnosticsStatus> result = checkConnectionToTimestampUrl();
+                log.info("result {}", result);
+
+                ActorSelection logManagerSelection = actorSystem.actorSelection("/user/LogManager");
+
+                Timeout timeout = new Timeout(DIAGNOSTICS_CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 try {
-                    log.info("/timestampstatus");
-
-                    Map<String, DiagnosticsStatus> result = checkConnectionToTimestampUrl();
-                    log.info("result {}", result);
-
-                    ActorSelection logManagerSelection = actorSystem.actorSelection("/user/LogManager");
-
-                    Timeout timeout = new Timeout(DIAGNOSTICS_CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                     Map<String, DiagnosticsStatus> statusFromLogManager = (Map<String, DiagnosticsStatus>) Await.result(
                             Patterns.ask(
                                     logManagerSelection, CommonMessages.TIMESTAMP_STATUS, timeout),
-                                    timeout.duration());
+                            timeout.duration());
 
                     log.info("statusFromLogManager {}", statusFromLogManager.toString());
 
                     // Use the status either from simple connection check or from LogManager.
                     for (String key : result.keySet()) {
                         // If status exists in LogManager for given timestamp server, and it is successful or if
-                        // simple connection check status is unsuccesful, use the status from LogManager
+                        // simple connection check status is unsuccessful, use the status from LogManager
                         if (statusFromLogManager.get(key) != null
                                 && (DiagnosticsErrorCodes.RETURN_SUCCESS == statusFromLogManager.get(key)
                                 .getReturnCode() && DiagnosticsErrorCodes.RETURN_SUCCESS == result.get(key)
@@ -272,18 +274,33 @@ public final class ProxyMain {
                             result.get(key).setReturnCodeNow(DiagnosticsErrorCodes.ERROR_CODE_TIMESTAMP_UNINITIALIZED);
                         }
                     }
+                } catch (Exception e) {
+                    log.error("Unable to connect to LogManager, immediate timestamping status unavailable", e);
+                    transmuteErrorCodes(result, DiagnosticsErrorCodes.RETURN_SUCCESS,
+                            DiagnosticsErrorCodes.ERROR_CODE_LOGMANAGER_UNAVAILABLE);
+                }
 
+                try {
                     response.setCharacterEncoding("UTF8");
                     JsonUtils.getSerializer().toJson(result, response.getWriter());
-
-                } catch (Exception e) {
-                    log.error("Error getting timeout status", e);
+                } catch (IOException e) {
+                    log.error("Unable to write to provided response, delegated request handling failed, response may"
+                            + " be malformed");
                 }
             }
         });
 
         return adminPort;
     }
+
+    private static void transmuteErrorCodes(Map<String, DiagnosticsStatus> map, int oldErrorCode, int newErrorCode) {
+        map.forEach((key, value) -> {
+            if (value != null && oldErrorCode == value.getReturnCode()) {
+                value.setReturnCodeNow(newErrorCode);
+            }
+        });
+    }
+
 
     private static Map<String, DiagnosticsStatus> checkConnectionToTimestampUrl() {
         Map<String, DiagnosticsStatus> statuses = new HashMap<>();


### PR DESCRIPTION
Fixes the entire diagnostics view breaking when any single subsection of it fails to determine its service status. Now the view defaults to empty sections if the parsing of the response fails.  Contains following changes/improvements:

- Refactored the proxy admin port handler implementation to be able to detect if the LogManager connection timeouts (e.g. when message log not available) and to differentiate that from completely failing to fetch a status
- Added a new error status description for the failure to connect to LogManager (depicted as an error with the red indicator) 
- Added error handling for parsing/deserializing the Java-response in JRuby and refactored the handling of responses to be more uniform within the limits of the response type variation
- Fixed an issue where times were displayed in different formats depending on the response type of the service query (now displayed in HH:mm with single digit preceding zeros for all services)
- Added more information of the diagnostics view logic to the security server user guide including the missing OCSP-responder description
- Several small style, translation and comment fixes related to the diagnostics view