### PR TITLE
PVAYLADEV-780: Update jetty and its logback module, switch to logback…

### DIFF
--- a/src/common-util/build.gradle
+++ b/src/common-util/build.gradle
@@ -25,8 +25,8 @@ dependencies {
 
     compile 'org.eclipse.jetty:jetty-server:9.4.2.v20170220'
 
-    compile 'ch.qos.logback:logback-access:1.1.3'
-    compile 'ch.qos.logback:logback-classic:1.1.3'
+    compile 'ch.qos.logback:logback-access:1.2.3'
+    compile 'ch.qos.logback:logback-classic:1.2.3'
 
     compile ('org.quartz-scheduler:quartz:2.1.6') {
         exclude module: 'c3p0'

--- a/src/common-util/src/main/java/ee/ria/xroad/common/XRoadSizeBasedRollingPolicy.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/XRoadSizeBasedRollingPolicy.java
@@ -22,32 +22,27 @@
  */
  package ee.ria.xroad.common;
 
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
+import ch.qos.logback.core.rolling.RolloverFailure;
+import ch.qos.logback.core.rolling.helper.*;
+
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import ch.qos.logback.core.CoreConstants;
-import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
-import ch.qos.logback.core.rolling.RolloverFailure;
-import ch.qos.logback.core.rolling.helper.CompressionMode;
-import ch.qos.logback.core.rolling.helper.Compressor;
-import ch.qos.logback.core.rolling.helper.FileFilterUtil;
-import ch.qos.logback.core.rolling.helper.FileNamePattern;
-import ch.qos.logback.core.rolling.helper.IntegerTokenConverter;
-import ch.qos.logback.core.rolling.helper.RenameUtil;
-
 /**
  * This class is largely a copy of Logback's FixedWindowRollingPolicy.
- *
+ *<p>
  * Replaces '%i' with timestamp and index number (necessary if there already
  * exists log for the same second). For example: '2015-10-12_165611-004'
- *
- * Work-around for problem related to RM task #7900 and Logback bug
- * http://jira.qos.ch/browse/LOGBACK-992
- *
- * FUTURE if Logback bug gets fixed, use TimeBasedRollingPolicy once again and
- * throw away this class.
+ *</p><p>
+ * This class was a work-around for
+ * http://jira.qos.ch/browse/LOGBACK-992<br>
+ *</p>
+ * <b>This class will be removed in a future release.</b>
  */
+@Deprecated
 public class XRoadSizeBasedRollingPolicy extends FixedWindowRollingPolicy {
     static final String FNP_NOT_SET = "The \"FileNamePattern\" property must "
             + "be set before using FixedWindowRollingPolicy. ";

--- a/src/packages/build-jetty-rpm.sh
+++ b/src/packages/build-jetty-rpm.sh
@@ -16,12 +16,6 @@ SNAPSHOT=$DATE$HASH
 ROOT=${DIR}/xroad-jetty9/redhat
 mkdir -p $ROOT/SOURCES
 cd $ROOT/SOURCES
-md5a=$(cat logging.mod.md5 || echo X)
-md5b=$(md5 logging.mod || echo Y)
-if [[ ! -f logging.mod || "$md5a" != "$md5b" ]]; then
-    curl -sLO "https://raw.githubusercontent.com/jetty-project/logging-modules/master/logback/logging.mod"
-    md5 logging.mod > logging.mod.md5
-fi
 md5a=$(cat jetty.md5 || echo X)
 md5b=$(md5 $(basename $JETTY) || echo Y)
 if [[ ! -f $(basename $JETTY) || "$md5a" != "$md5b" ]]; then

--- a/src/packages/default-configuration/confclient-logback-service.xml
+++ b/src/packages/default-configuration/confclient-logback-service.xml
@@ -5,15 +5,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/configuration_client.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/configuration_client.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/configuration_client.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
             <charset>UTF-8</charset>

--- a/src/packages/default-configuration/confclient-logback.xml
+++ b/src/packages/default-configuration/confclient-logback.xml
@@ -5,15 +5,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/configuration_client.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/configuration_client.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/configuration_client.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
             <charset>UTF-8</charset>

--- a/src/packages/default-configuration/confproxy-logback.xml
+++ b/src/packages/default-configuration/confproxy-logback.xml
@@ -5,15 +5,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/confproxy.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/confproxy.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/confproxy.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
             <charset>UTF-8</charset>

--- a/src/packages/default-configuration/op-monitor-logback.xml
+++ b/src/packages/default-configuration/op-monitor-logback.xml
@@ -5,15 +5,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/op-monitor.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/op-monitor.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/op-monitor.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
             <charset>UTF-8</charset>

--- a/src/packages/default-configuration/proxy-logback.xml
+++ b/src/packages/default-configuration/proxy-logback.xml
@@ -5,15 +5,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/proxy.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/proxy.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/proxy.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
             <charset>UTF-8</charset>

--- a/src/packages/default-configuration/signer-console-logback.xml
+++ b/src/packages/default-configuration/signer-console-logback.xml
@@ -6,15 +6,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/signer-console.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/signer-console.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/signer-console.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>%d %-5level [%thread] %logger{36} - %msg%n</pattern>
             <charset>UTF-8</charset>

--- a/src/packages/default-configuration/signer-logback.xml
+++ b/src/packages/default-configuration/signer-logback.xml
@@ -5,15 +5,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/signer.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/signer.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/signer.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>%d %-5level [%thread] %logger{36} - %msg%n</pattern>
             <charset>UTF-8</charset>

--- a/src/packages/xroad-jetty9/debian/rules
+++ b/src/packages/xroad-jetty9/debian/rules
@@ -36,9 +36,6 @@ build:
 	mv ~/jetty/jetty-distribution* jetty9
 	rm -rf jetty9/lib/setuid
 	rm -rf jetty9/demo-base
-	curl -o jetty9/modules/logging.mod -O https://raw.githubusercontent.com/jetty-project/logging-modules/master/logback/logging.mod
-	sed -i'' 's/^resources/#resources/' jetty9/modules/logging.mod
-	sed -i'' 's/1\.0\.7/1\.1\.3/g' jetty9/modules/logging.mod
-	sed -i'' 's/^logs/#logs/' jetty9/modules/logging.mod
+	sed -i'' 's/^logback\.version?=1\.1\.7/logback\.version\?=1\.2\.3/' jetty9/modules/logback-impl.mod
 	mv jetty9/start.ini jetty9/start.ini.bak
-	java -jar jetty9/start.jar --add-to-start=logging jetty.base=jetty9
+	echo yes |java -jar jetty9/start.jar --add-to-start=logging-logback jetty.base=jetty9

--- a/src/packages/xroad-jetty9/debian/xroad-jetty9.links
+++ b/src/packages/xroad-jetty9/debian/xroad-jetty9.links
@@ -1,4 +1,5 @@
 etc/xroad/jetty/jetty-login.conf usr/share/xroad/jetty9/etc/login.conf
 etc/xroad/jetty/xroad.mod usr/share/xroad/jetty9/modules/xroad.mod
 etc/xroad/jetty/start.ini usr/share/xroad/jetty9/start.ini
+etc/xroad/conf.d/jetty-logback.xml usr/share/xroad/jetty9/resources/logback.xml
 

--- a/src/packages/xroad-jetty9/etc/xroad/conf.d/jetty-logback.xml
+++ b/src/packages/xroad-jetty9/etc/xroad/conf.d/jetty-logback.xml
@@ -6,15 +6,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/jetty.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/jetty.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/jetty.%d{yyyy-MM-dd}-%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
             <charset>UTF-8</charset>

--- a/src/packages/xroad-jetty9/etc/xroad/jetty/start.ini
+++ b/src/packages/xroad-jetty9/etc/xroad/jetty/start.ini
@@ -2,4 +2,4 @@
 /etc/xroad/jetty/jetty-public.xml
 --exec-properties=/var/tmp/xroad/jetty_start.properties
 --module=xroad
---module=logging
+--module=logging-logback

--- a/src/packages/xroad-jetty9/jetty.url
+++ b/src/packages/xroad-jetty9/jetty.url
@@ -1,2 +1,2 @@
-http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.3.11.v20160721/jetty-distribution-9.3.11.v20160721.tar.gz
+https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.5.v20170502/jetty-distribution-9.4.5.v20170502.tar.gz
 

--- a/src/packages/xroad-jetty9/redhat/SPECS/xroad-jetty9.spec
+++ b/src/packages/xroad-jetty9/redhat/SPECS/xroad-jetty9.spec
@@ -37,17 +37,17 @@ Jetty9 modified for X-Road usage. Used by web services.
 
 %build
 rm -rf demo-base
-cp %{SOURCE1} modules/logging.mod
-sed -i'' 's/^resources/#resources/' modules/logging.mod
-sed -i'' 's/^logs/#logs/' modules/logging.mod
+sed -i'' 's/^logback\.version?=1\.1\.7/logback\.version\?=1\.2\.3/' modules/logback-impl.mod
 mv start.ini start.ini.bak
-java -jar start.jar --add-to-start=logging jetty.base=$(pwd)
+echo yes |java -jar start.jar --add-to-start=logging-logback jetty.base=$(pwd)
 
 %install
 ln -s /etc/xroad/jetty/jetty-login.conf etc/login.conf
 ln -s /etc/xroad/jetty/xroad.mod modules/xroad.mod
 rm -f start.ini
 ln -s /etc/xroad/jetty/start.ini start.ini
+rm -f resources/logback.xml
+ln -s /etc/xroad/conf.d/jetty-logback.xml resources/logback.xml
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}/usr/share/xroad/jetty9

--- a/src/proxy/src/main/resources/logback-access-clientproxy.xml
+++ b/src/proxy/src/main/resources/logback-access-clientproxy.xml
@@ -3,15 +3,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/xroad/clientproxy_access.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/clientproxy_access.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/clientproxy_access.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>combined</pattern>
             <charset>UTF-8</charset>

--- a/src/proxy/src/main/resources/logback-access-serverproxy.xml
+++ b/src/proxy/src/main/resources/logback-access-serverproxy.xml
@@ -3,15 +3,10 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/xroad/serverproxy_access.log</file>
-        <!-- NB! Use ee.ria.xroad.common.XRoadSizeBasedRollingPolicy rolling -->
-        <!-- policy instead of ch.qos.logback.core.rolling.TimeBasedRollingPolicy -->
-        <!-- as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992 -->
-        <rollingPolicy class="ee.ria.xroad.common.XRoadSizeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/serverproxy_access.%i.log.zip</fileNamePattern>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/serverproxy_access.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
+        </rollingPolicy>
         <encoder>
             <pattern>combined</pattern>
             <charset>UTF-8</charset>

--- a/src/serverconf/build.gradle
+++ b/src/serverconf/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     schema 'org.hibernate:hibernate-hikaricp:4.3.11.Final'
     schema 'org.hibernate:hibernate-tools:4.3.5.Final'
     schema 'commons-collections:commons-collections:3.2.2'
-    schema 'ch.qos.logback:logback-classic:1.1.3'
+    schema 'ch.qos.logback:logback-classic:1.2.3'
     schema 'org.hsqldb:hsqldb:2.3.2'
 }
 


### PR DESCRIPTION
… log rolling policy instead of workaround.

The goal is to stop using the 
ee.ria.xroad.common.XRoadSizeBasedRollingPolicy as a workaround for Logback bug http://jira.qos.ch/browse/LOGBACK-992

It is fixed in logback 1.1.5. This PR updates xroad-jetty to use jetty 9.4.5, which includes an internal logback module so we don't have to use a custom module anymore. Sadly, this module has logback version 1.1.7 which re-introduces the same bug. The logback version is therefore configured to be 1.2.3.

Both module and library version of logback is updated to 1.2.3. The embedded jetty library remains at 9.4.2.

Including the module now asks to agree to a license, an "echo yes" is piped to the question during building the packages.

The custom rolling policy will generate zip files with a creation time and an index in the zip file name. The logback one has an auxiliary date available for the filename (https://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy), but the time it generates does not seem to be related to the zip creation time.

The custom rolliing policy was removed from all configuration files, but the class remains and is marked as deprecated. The class remains usable in a configuration but is planned to be removed in a later release.