### PR TITLE
PVAYLADEV-807: Maintenance mode for the load balancer health check interface

### DIFF
--- a/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md
+++ b/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md
@@ -8,7 +8,7 @@ Doc. ID: IG-XLB
 |-------------|-------------|---------------------------------------------------------|------------------------------|
 | 22.3.2017   | 1.0         | Initial version                                         | Jarkko Hyöty, Olli Lindgren  |
 | 27.4.2017   | 1.1         | Added slave node user group instructions                | Tatu Repo                    |
-
+| 15.6.2017   | 1.2         | Added health check interface maintenance mode           | Tatu Repo                    |
 
 ## Table of Contents
 
@@ -331,6 +331,24 @@ as fresh as possible while avoiding per-request verification. In contrast, verif
 seconds before a new verification is triggered. This should allow for the security server to get up and running after a
 failure or possible reboot before the status is queried again.
 
+Security server's health check interface can also be manually switched to a maintenance mode in order to inform the load
+balancing solution that the security server will be undergoing maintenance and should be removed from active use.
+
+When in maintenance mode the health check interface will only respond with `HTTP 503 Service unavailable` and the message
+`Health check interface is in maintenance mode` and no actual health check diagnostics will be run. Maintenance mode is disabled
+by default and will automatically reset to its default when the proxy service is restarted. 
+
+Maintenance mode can be enabled or disabled by sending `HTTP GET`-request from the target security server to its proxy admin port `5566`.
+The intended new state can be defined using the `targetState` HTTP-parameter:
+
+|Command|URI|
+|---|---|
+|Enable maintenance mode|`http://localhost:5566/maintenance?targetState=true`|
+|Disable maintenance mode|`http://localhost:5566/maintenance?targetState=false`|
+
+Proxy admin port will respond with `200 OK` and a message detailing the actualized maintenance mode state change,
+e.g. `Maintenance mode set: false => true`. In case the maintenance mode state could not be changed, the returned
+message will detail the reason. 
 
 #### 3.4.1 Known check result inconsistencies vs. actual state
 There is a known but rarely and not naturally occurring issue where the health check will report an OK condition for a

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckPort.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckPort.java
@@ -73,6 +73,13 @@ public class HealthCheckPort implements StartStop {
         createHealthCheckConnector();
     }
 
+    HealthCheckPort(StoppableHealthCheckProvider testProvider, int testPort) {
+        server = new Server(new QueuedThreadPool(THREAD_POOL_SIZE));
+        stoppableHealthCheckProvider = testProvider;
+        portNumber = testPort;
+        createHealthCheckConnector();
+    }
+
     private void createHealthCheckConnector() {
 
         ServerConnector connector = new ServerConnector(server, ACCEPTOR_THREAD_COUNT, SELECTOR_THREAD_COUNT);

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckPort.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckPort.java
@@ -108,8 +108,7 @@ public class HealthCheckPort implements StartStop {
         return "Maintenance mode set: "
                 + oldValue
                 + " => "
-                + targetState
-                + System.lineSeparator();
+                + targetState;
     }
 
     public boolean isMaintenanceMode() {
@@ -156,7 +155,7 @@ public class HealthCheckPort implements StartStop {
 
             if (isMaintenanceMode()) {
                 response.setStatus(SC_SERVICE_UNAVAILABLE);
-                response.getWriter().write(MAINTENANCE_MESSAGE.concat(System.lineSeparator()));
+                response.getWriter().println(MAINTENANCE_MESSAGE);
             } else {
                 HealthCheckResult result = healthCheckProvider.get();
                 if (result.isOk()) {

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
@@ -297,12 +297,12 @@ public final class ProxyMain {
                     boolean targetState = Boolean.valueOf(param);
                     result = setHealthCheckMaintenanceMode(targetState);
                 } else {
-                    result = "Invalid parameter 'targetState', request ignored";
+                    result = "Invalid parameter 'targetState', request ignored" + System.lineSeparator();
                 }
 
                 try {
                     response.setCharacterEncoding("UTF8");
-                    JsonUtils.getSerializer().toJson(result, response.getWriter());
+                    response.getWriter().write(result);
                 } catch (IOException e) {
                     log.error("Unable to write to provided response, delegated request handling failed, response may"
                             + " be malformed", e);
@@ -314,18 +314,12 @@ public final class ProxyMain {
     }
 
     private static String setHealthCheckMaintenanceMode(boolean targetState) {
-        String result;
-        Optional<StartStop> healthCheckPort = SERVICES.stream()
+        return SERVICES.stream()
                 .filter(HealthCheckPort.class::isInstance)
-                .findFirst();
-
-        if (healthCheckPort.isPresent()) {
-            HealthCheckPort port = (HealthCheckPort) healthCheckPort.get();
-            result = port.setMaintenanceMode(targetState);
-        } else {
-            result = "No health check service found, unable to set mode";
-        }
-        return result;
+                .map(HealthCheckPort.class::cast)
+                .findFirst()
+                .map(port -> port.setMaintenanceMode(targetState))
+                .orElse("No HealthCheckPort found, maintenance mode not set" + System.lineSeparator());
     }
 
     private static void transmuteErrorCodes(Map<String, DiagnosticsStatus> map, int oldErrorCode, int newErrorCode) {

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
@@ -290,19 +290,15 @@ public final class ProxyMain {
             @Override
             public void handle(HttpServletRequest request, HttpServletResponse response) {
 
-                String result;
+                String result = "Invalid parameter 'targetState', request ignored";
                 String param = request.getParameter("targetState");
 
                 if (param != null && (param.equalsIgnoreCase("true") || param.equalsIgnoreCase("false"))) {
-                    boolean targetState = Boolean.valueOf(param);
-                    result = setHealthCheckMaintenanceMode(targetState);
-                } else {
-                    result = "Invalid parameter 'targetState', request ignored" + System.lineSeparator();
+                    result = setHealthCheckMaintenanceMode(Boolean.valueOf(param));
                 }
-
                 try {
                     response.setCharacterEncoding("UTF8");
-                    response.getWriter().write(result);
+                    response.getWriter().println(result);
                 } catch (IOException e) {
                     log.error("Unable to write to provided response, delegated request handling failed, response may"
                             + " be malformed", e);
@@ -319,7 +315,7 @@ public final class ProxyMain {
                 .map(HealthCheckPort.class::cast)
                 .findFirst()
                 .map(port -> port.setMaintenanceMode(targetState))
-                .orElse("No HealthCheckPort found, maintenance mode not set" + System.lineSeparator());
+                .orElse("No HealthCheckPort found, maintenance mode not set");
     }
 
     private static void transmuteErrorCodes(Map<String, DiagnosticsStatus> map, int oldErrorCode, int newErrorCode) {

--- a/src/proxy/src/test/java/ee/ria/xroad/common/util/healthcheck/MaintenanceModeTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/common/util/healthcheck/MaintenanceModeTest.java
@@ -1,0 +1,142 @@
+/**
+ * The MIT License
+ * Copyright (c) 2015 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ee.ria.xroad.common.util.healthcheck;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Tests setting {@link HealthCheckPort} on and off maintenance mode
+ */
+public class MaintenanceModeTest {
+
+    private HealthCheckPort testPort;
+    private StoppableHealthCheckProvider testProvider;
+    private static HttpGet healthCheckGet;
+    private static CloseableHttpClient testClient;
+
+    private static final int testPortNumber = 8555;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws URISyntaxException {
+        URI healthCheckURI = new URIBuilder()
+                .setScheme("http")
+                .setHost("localhost")
+                .setPort(testPortNumber)
+                .build();
+
+        healthCheckGet = new HttpGet(healthCheckURI);
+        testClient = HttpClients.createDefault();
+    }
+
+    @Before
+    public void setUp() {
+        testProvider = mock(StoppableCombinationHealthCheckProvider.class);
+        testPort = new HealthCheckPort(testProvider, testPortNumber);
+    }
+
+    /**
+     * Tests {@link HealthCheckPort} operation when it's in maintenance mode
+     * - verifies that internal provider does not get called during maintenance mode
+     * - verifies that HTTP status code 503 is returned due to maintenance mode
+     * @throws IOException client and response operation can throw an IOException that should fail the test
+     */
+    @Test
+    public void maintenanceModeOnShouldPreventProviderCalls() throws IOException {
+        try {
+            testPort.start();
+        } catch (Exception e) {
+            fail("HealthCheckPort start() failed: " + e.getMessage());
+        }
+        testPort.setMaintenanceMode(true);
+        try (CloseableHttpResponse response = testClient.execute(healthCheckGet)) {
+            verify(testProvider, times(0)).get();
+            assertEquals(HttpServletResponse.SC_SERVICE_UNAVAILABLE, response.getStatusLine().getStatusCode());
+        }
+
+    }
+
+    /**
+     * Tests {@link HealthCheckPort} operation when it's not in maintenance mode
+     * - verifies that internal provider does get called when not in maintenance mode
+     * - verifies that mock provider's OK result gets through HealthCheckPort as HTTP OK when not in maintenance mode
+     * @throws IOException client and response operation can throw an IOException that should fail the test
+     */
+    @Test
+    public void maintenanceModeOffShouldNotAffectProviderCalls() throws IOException {
+
+        when(testProvider.get()).thenReturn(HealthCheckResult.OK);
+
+        try {
+            testPort.start();
+        } catch (Exception e) {
+            fail("HealthCheckPort start() failed: " + e.getMessage());
+        }
+        testPort.setMaintenanceMode(false);
+        try (CloseableHttpResponse response = testClient.execute(healthCheckGet)) {
+            verify(testProvider, times(1)).get();
+            assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (testPort != null) {
+            try {
+                testPort.stop();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @AfterClass
+    public static void afterClassTearDown() {
+        if (testClient != null) {
+            try {
+                testClient.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+}

--- a/src/proxy/src/test/java/ee/ria/xroad/common/util/healthcheck/MaintenanceModeTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/common/util/healthcheck/MaintenanceModeTest.java
@@ -56,7 +56,7 @@ public class MaintenanceModeTest {
     private static HttpGet healthCheckGet;
     private static CloseableHttpClient testClient;
 
-    private static final int TEST_PORT_NUMBER = 8555;
+    private static final int TEST_PORT_NUMBER = 23555;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -104,12 +104,12 @@ public class MaintenanceModeTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(testProvider.get()).thenReturn(HealthCheckResult.OK);
     }
 
     @After
-    public void tearDown() throws IOException {
+    public void tearDown() {
         reset(testProvider);
     }
 


### PR DESCRIPTION
Implements an internal state flag for the HealthCheckPort instance that can be set using the proxy admin port target `maintenance` and HTTP-parameter `targetState`.

Includes:
- proxy admin port handler for maintenance requests
- internal flag for HealthCheckPort with accessors and accompanying override logic for the request handler
- unit tests
- documentation 