### PR TITLE
PVAYLADEV-856: Exclude audit.log from log cleanup

### DIFF
--- a/ansible/roles/xroad-base/tasks/main.yml
+++ b/ansible/roles/xroad-base/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: clean xroad logs at boot
   cron:
     name: xroad log cleanup
-    job: "/usr/bin/find /var/log/xroad -type f \\( -name '*.log' -o -name '*.log.zip' \\) -mtime +1 -exec rm {{ '{} \\;' }} > /dev/null 2>&1"
+    job: "/usr/bin/find /var/log/xroad -type f -not -name audit.log \\( -name '*.log' -o -name '*.log.zip' \\) -mtime +1 -exec rm {{ '{} \\;' }} > /dev/null 2>&1"
     special_time: reboot
     cron_file: xroad_log_cleanup
     user: xroad


### PR DESCRIPTION
Removing audit.log causes rsyslog to continue logging to the now deleted
file. There is already a logrotate configuration for audit.log which
should be enough.