### PR TITLE
PVAYLADEV-847: Double clicking an empty row in a table attempts to perform a selection 

### DIFF
--- a/src/center-ui/public/javascripts/cas.js
+++ b/src/center-ui/public/javascripts/cas.js
@@ -39,13 +39,17 @@ var XROAD_CAS = function() {
 
         enableActions();
 
-        $("#cas").on("click", "tbody tr", function() {
+        var casTable = $("#cas");
+
+        var caDetailsButton = $("#ca_details");
+
+        casTable.on("click", "tbody tr", function() {
             cas.setFocus(0, this);
             enableActions();
         });
 
-        $("#cas").on("dblclick", "tbody tr", function() {
-            XROAD_APPROVED_CA_DIALOG.openEditDialog(cas.getFocusData());
+        casTable.on("dblclick", "tbody tr", function() {
+            caDetailsButton.click();
         });
 
         $("#ca_add").click(function() {
@@ -53,7 +57,11 @@ var XROAD_CAS = function() {
         });
 
         $("#ca_details").click(function() {
-            XROAD_APPROVED_CA_DIALOG.openEditDialog(cas.getFocusData());
+            var itemData = cas.getFocusData();
+            if (itemData && itemData.hasOwnProperty("id")) {
+                XROAD_APPROVED_CA_DIALOG.openEditDialog(itemData);
+            }
+
         });
 
         $("#ca_delete").click(function() {

--- a/src/center-ui/public/javascripts/cas.js
+++ b/src/center-ui/public/javascripts/cas.js
@@ -48,7 +48,7 @@ var XROAD_CAS = function() {
             enableActions();
         });
 
-        casTable.on("dblclick", "tbody tr", function() {
+        casTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             caDetailsButton.click();
         });
 
@@ -56,12 +56,8 @@ var XROAD_CAS = function() {
             XROAD_APPROVED_CA_DIALOG.openAddDialog();
         });
 
-        $("#ca_details").click(function() {
-            var itemData = cas.getFocusData();
-            if (itemData && itemData.hasOwnProperty("id")) {
-                XROAD_APPROVED_CA_DIALOG.openEditDialog(itemData);
-            }
-
+        caDetailsButton.click(function() {
+            XROAD_APPROVED_CA_DIALOG.openEditDialog(cas.getFocusData());
         });
 
         $("#ca_delete").click(function() {

--- a/src/center-ui/public/javascripts/cas.js
+++ b/src/center-ui/public/javascripts/cas.js
@@ -43,12 +43,12 @@ var XROAD_CAS = function() {
 
         var caDetailsButton = $("#ca_details");
 
-        casTable.on("click", "tbody tr", function() {
+        casTable
+        .on("click", "tbody tr", function() {
             cas.setFocus(0, this);
             enableActions();
-        });
-
-        casTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+        })
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             caDetailsButton.click();
         });
 

--- a/src/center-ui/public/javascripts/centerui_common.js
+++ b/src/center-ui/public/javascripts/centerui_common.js
@@ -91,6 +91,6 @@ var XROAD_CENTERUI_COMMON = function() {
         updateRecordsCount: updateRecordsCount,
         limitDialogHeight: limitDialogHeight,
         getTranslatedRequestType: getTranslatedRequestType,
-        translateRequestType, translateRequestType
+        translateRequestType: translateRequestType
     };
 }();

--- a/src/center-ui/public/javascripts/central_service_edit.js
+++ b/src/center-ui/public/javascripts/central_service_edit.js
@@ -244,13 +244,12 @@ var XROAD_CENTRAL_SERVICE_EDIT = function() {
 
         oProviders = providerTable.dataTable(opts);
 
-        providerTable.on("click", "tbody tr", function(ev) {
+        providerTable
+        .on("click", "tbody tr", function(ev) {
             oProviders.setFocus(0, ev.target.parentNode)
-        });
-
-
-        providerTable.off("dblclick")
-            .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+        })
+        .off("dblclick")
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             fillProviderData(oProviders.getFocusData());
             $("#central_service_member_search_dialog").dialog("close");
         });

--- a/src/center-ui/public/javascripts/central_service_edit.js
+++ b/src/center-ui/public/javascripts/central_service_edit.js
@@ -239,16 +239,18 @@ var XROAD_CENTRAL_SERVICE_EDIT = function() {
         };
 
         opts.aaSorting = [ [1,'asc'] ];
+        var providerTable = $("#central_service_details_providers");
 
-        oProviders = $('#central_service_details_providers').dataTable(opts);
 
-        $("#central_service_details_providers tbody tr").live(
-                "click", function(ev) {
+        oProviders = providerTable.dataTable(opts);
+
+        providerTable.on("click", "tbody tr", function(ev) {
             oProviders.setFocus(0, ev.target.parentNode)
         });
 
-        $("#central_service_details_providers tbody tr")
-                .unbind("dblclick").live("dblclick", function() {
+
+        providerTable.off("dblclick")
+            .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             fillProviderData(oProviders.getFocusData());
             $("#central_service_member_search_dialog").dialog("close");
         });

--- a/src/center-ui/public/javascripts/central_services.js
+++ b/src/center-ui/public/javascripts/central_services.js
@@ -67,19 +67,26 @@ var XROAD_CENTRAL_SERVICES = function () {
         enableActions();
         focusInput();
 
-        $("#central_services tbody tr").live("click", function(ev) {
+        var servicesTable = $("#central_services");
+
+        var serviceDetailsButton = $("#central_service_details");
+
+        servicesTable.on("click", "tbody tr", function(ev) {
             if (oCentralServices.setFocus(0, ev.target.parentNode) &&
-                    $("#central_service_details_form:visible").length == 0) {
+                    $("#central_service_details_form:visible").length === 0) {
                 $(".central_service-action").enable();
             }
         });
 
-        $("#central_services tbody tr").live("dblclick", function() {
-            XROAD_CENTRAL_SERVICE_EDIT.open(oCentralServices.getFocusData());
+        servicesTable.on("dblclick", "tbody tr", function() {
+            serviceDetailsButton.click();
         });
 
-        $("#central_service_details").click(function() {
-            XROAD_CENTRAL_SERVICE_EDIT.open(oCentralServices.getFocusData());
+        serviceDetailsButton.click(function() {
+            var itemData = oCentralServices.getFocusData();
+            if (itemData && itemData.hasOwnProperty("central_service_code")) {
+                XROAD_CENTRAL_SERVICE_EDIT.open(itemData);
+            }
         });
 
         $("#central_service_add").click(function() {

--- a/src/center-ui/public/javascripts/central_services.js
+++ b/src/center-ui/public/javascripts/central_services.js
@@ -78,15 +78,12 @@ var XROAD_CENTRAL_SERVICES = function () {
             }
         });
 
-        servicesTable.on("dblclick", "tbody tr", function() {
+        servicesTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             serviceDetailsButton.click();
         });
 
         serviceDetailsButton.click(function() {
-            var itemData = oCentralServices.getFocusData();
-            if (itemData && itemData.hasOwnProperty("central_service_code")) {
-                XROAD_CENTRAL_SERVICE_EDIT.open(itemData);
-            }
+            XROAD_CENTRAL_SERVICE_EDIT.open(oCentralServices.getFocusData());
         });
 
         $("#central_service_add").click(function() {

--- a/src/center-ui/public/javascripts/central_services.js
+++ b/src/center-ui/public/javascripts/central_services.js
@@ -71,14 +71,14 @@ var XROAD_CENTRAL_SERVICES = function () {
 
         var serviceDetailsButton = $("#central_service_details");
 
-        servicesTable.on("click", "tbody tr", function(ev) {
+        servicesTable
+        .on("click", "tbody tr", function(ev) {
             if (oCentralServices.setFocus(0, ev.target.parentNode) &&
                     $("#central_service_details_form:visible").length === 0) {
                 $(".central_service-action").enable();
             }
-        });
-
-        servicesTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+        })
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             serviceDetailsButton.click();
         });
 

--- a/src/center-ui/public/javascripts/configuration_sources.js
+++ b/src/center-ui/public/javascripts/configuration_sources.js
@@ -1,4 +1,5 @@
 var XROAD_CONFIGURATION_SOURCE = function() {
+var XROAD_CONFIGURATION_SOURCE = function() {
     var oSigningKeys, oConfParts;
     var tab = "#source_tab";
 

--- a/src/center-ui/public/javascripts/configuration_sources.js
+++ b/src/center-ui/public/javascripts/configuration_sources.js
@@ -1,5 +1,4 @@
 var XROAD_CONFIGURATION_SOURCE = function() {
-var XROAD_CONFIGURATION_SOURCE = function() {
     var oSigningKeys, oConfParts;
     var tab = "#source_tab";
 

--- a/src/center-ui/public/javascripts/groups.js
+++ b/src/center-ui/public/javascripts/groups.js
@@ -86,19 +86,25 @@ var XROAD_GROUPS = function() {
         enableActions();
         focusInput();
 
-        $("#global_groups tbody td").live("click", function(ev) {
+        var groupTable = $("#global_groups");
+        var groupDetailsButton = $("#group_details");
+
+        groupTable.on("click", "tbody tr", function(ev) {
             if (oGlobalGroups.setFocus(0, ev.target.parentNode) &&
-                    $("#add_group_form:visible").length == 0) {
+                    $("#add_group_form:visible").length === 0) {
                 $(".group-action").enable();
             }
         });
 
-        $("#global_groups tbody tr").live("dblclick", function() {
-            XROAD_GROUP_EDIT.open(oGlobalGroups.getFocusData());
+        groupTable.on("dblclick", "tbody tr", function() {
+            groupDetailsButton.click();
         });
 
-        $("#group_details").click(function() {
-            XROAD_GROUP_EDIT.open(oGlobalGroups.getFocusData());
+        groupDetailsButton.click(function() {
+            var itemData = oGlobalGroups.getFocusData();
+            if (itemData && itemData.hasOwnProperty("id")) {
+                XROAD_GROUP_EDIT.open(itemData);
+            }
         });
 
         $("#group_add_dialog").initDialog({

--- a/src/center-ui/public/javascripts/groups.js
+++ b/src/center-ui/public/javascripts/groups.js
@@ -89,14 +89,14 @@ var XROAD_GROUPS = function() {
         var groupTable = $("#global_groups");
         var groupDetailsButton = $("#group_details");
 
-        groupTable.on("click", "tbody tr", function(ev) {
+        groupTable
+        .on("click", "tbody tr", function(ev) {
             if (oGlobalGroups.setFocus(0, ev.target.parentNode) &&
                     $("#add_group_form:visible").length === 0) {
                 $(".group-action").enable();
             }
-        });
-
-        groupTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+        })
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             groupDetailsButton.click();
         });
 

--- a/src/center-ui/public/javascripts/groups.js
+++ b/src/center-ui/public/javascripts/groups.js
@@ -96,15 +96,12 @@ var XROAD_GROUPS = function() {
             }
         });
 
-        groupTable.on("dblclick", "tbody tr", function() {
+        groupTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             groupDetailsButton.click();
         });
 
         groupDetailsButton.click(function() {
-            var itemData = oGlobalGroups.getFocusData();
-            if (itemData && itemData.hasOwnProperty("id")) {
-                XROAD_GROUP_EDIT.open(itemData);
-            }
+            XROAD_GROUP_EDIT.open(oGlobalGroups.getFocusData());
         });
 
         $("#group_add_dialog").initDialog({

--- a/src/center-ui/public/javascripts/member_edit.js
+++ b/src/center-ui/public/javascripts/member_edit.js
@@ -496,7 +496,7 @@ var XROAD_MEMBER_EDIT = function() {
             }
         });
 
-        oAddableUsedServers.unbind("dblclick")
+        oAddableUsedServers.off("dblclick")
                 .on( "dblclick", "tbody td[class!=dataTables_empty]", function() {
             $("#member_securityserver_search_select").click();
         });

--- a/src/center-ui/public/javascripts/member_edit.js
+++ b/src/center-ui/public/javascripts/member_edit.js
@@ -489,15 +489,15 @@ var XROAD_MEMBER_EDIT = function() {
 
         oAddableUsedServers = $("#used_server_search_all").dataTable(opts);
 
-        oAddableUsedServers.on("click", "tbody td[class!=dataTables_empty]",
+        oAddableUsedServers
+        .on("click", "tbody td[class!=dataTables_empty]",
                 function(ev) {
             if (oAddableUsedServers.setFocus(0, ev.target.parentNode)) {
                 $("#member_securityserver_search_select").enable();
             }
-        });
-
-        oAddableUsedServers.off("dblclick")
-                .on( "dblclick", "tbody td[class!=dataTables_empty]", function() {
+        })
+        .off("dblclick")
+        .on( "dblclick", "tbody td[class!=dataTables_empty]", function() {
             $("#member_securityserver_search_select").click();
         });
     }

--- a/src/center-ui/public/javascripts/member_search_dialog.js
+++ b/src/center-ui/public/javascripts/member_search_dialog.js
@@ -49,14 +49,14 @@
         oMemberSearch = $("#member_search").dataTable(opts);
         oMemberSearch.fnSetFilteringDelay(600);
 
-        oMemberSearch.on("click", "tbody tr", function(ev) {
+        oMemberSearch
+        .on("click", "tbody tr", function(ev) {
             if (oMemberSearch.setFocus(0, this)) {
                 $("#member_search_select").enable();
             }
-        });
-
-        oMemberSearch.off("dblclick")
-                .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+        })
+        .off("dblclick")
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             $("#member_search_dialog").dialog("close");
             onSuccess(oMemberSearch.getFocusData());
         });

--- a/src/center-ui/public/javascripts/member_search_dialog.js
+++ b/src/center-ui/public/javascripts/member_search_dialog.js
@@ -55,10 +55,10 @@
             }
         });
 
-        oMemberSearch.unbind("dblclick")
-                .on("dblclick", "tbody tr", function(ev) {
+        oMemberSearch.off("dblclick")
+                .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             $("#member_search_dialog").dialog("close");
-            onSuccess(oMemberSearch.fnGetData(this));
+            onSuccess(oMemberSearch.getFocusData());
         });
     }
 

--- a/src/center-ui/public/javascripts/members.js
+++ b/src/center-ui/public/javascripts/members.js
@@ -121,7 +121,7 @@ var XROAD_MEMBERS = function() {
 
         var membersTable = $("#members");
 
-        membersTable.on("dblclick", "tbody tr", function() {
+        membersTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             $("#member_details").click();
         });
 
@@ -133,10 +133,7 @@ var XROAD_MEMBERS = function() {
         });
 
         $("#member_details").click(function() {
-            var itemData = oMembers.getFocusData();
-            if (itemData && itemData.hasOwnProperty("id")) {
-                XROAD_MEMBER_EDIT.open(itemData);
-            }
+            XROAD_MEMBER_EDIT.open(oMembers.getFocusData());
         });
         initTestability();
     });

--- a/src/center-ui/public/javascripts/members.js
+++ b/src/center-ui/public/javascripts/members.js
@@ -121,11 +121,11 @@ var XROAD_MEMBERS = function() {
 
         var membersTable = $("#members");
 
-        membersTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+        membersTable
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             $("#member_details").click();
-        });
-
-        membersTable.on("click", "tbody tr", function(ev) {
+        })
+        .on("click", "tbody tr", function(ev) {
             if (oMembers.setFocus(0, ev.target.parentNode) &&
                 $("#add_form:visible").length === 0) {
                 $(".member-action").enable();

--- a/src/center-ui/public/javascripts/members.js
+++ b/src/center-ui/public/javascripts/members.js
@@ -90,14 +90,6 @@ var XROAD_MEMBERS = function() {
         enableActions();
         focusInput();
 
-        $("#members tbody td[class!=dataTables_empty]").live("click",
-                function(ev) {
-            if (oMembers.setFocus(0, ev.target.parentNode) &&
-                    $("#add_form:visible").length == 0) {
-                $(".member-action").enable();
-            }
-        });
-
         $("#add").ajaxError(function(ev, xhr) {
             $("#save_ok, #save_cancel").enable();
             $("#fullName, #shortName").removeAttr("readonly");
@@ -127,19 +119,24 @@ var XROAD_MEMBERS = function() {
             $("#member_add_dialog").dialog("open");
         });
 
-        $("#members tbody tr").live("dblclick", function() {
-            XROAD_MEMBER_EDIT.open(oMembers.getFocusData());
+        var membersTable = $("#members");
+
+        membersTable.on("dblclick", "tbody tr", function() {
+            $("#member_details").click();
         });
 
-        $("#members tbody td").live("click", function(ev) {
+        membersTable.on("click", "tbody tr", function(ev) {
             if (oMembers.setFocus(0, ev.target.parentNode) &&
-                $("#add_form:visible").length == 0) {
+                $("#add_form:visible").length === 0) {
                 $(".member-action").enable();
             }
         });
 
         $("#member_details").click(function() {
-            XROAD_MEMBER_EDIT.open(oMembers.getFocusData());
+            var itemData = oMembers.getFocusData();
+            if (itemData && itemData.hasOwnProperty("id")) {
+                XROAD_MEMBER_EDIT.open(itemData);
+            }
         });
         initTestability();
     });

--- a/src/center-ui/public/javascripts/requests.js
+++ b/src/center-ui/public/javascripts/requests.js
@@ -134,13 +134,10 @@ var XROAD_REQUESTS = function() {
 
     function openRequestDetails() {
         var request = oManagementRequests.getFocusData();
-        if (request && request.hasOwnProperty("id")) {
-            var updateTablesCallback = function() {
-                updateTable();
-            }
-
-            XROAD_REQUEST_EDIT.open(request, updateTablesCallback);
-        }
+        var updateTablesCallback = function() {
+            updateTable();
+        };
+        XROAD_REQUEST_EDIT.open(request, updateTablesCallback);
     }
 
     function getTranslatedRequestType(rawRequestType) {
@@ -163,7 +160,7 @@ var XROAD_REQUESTS = function() {
             }
         });
 
-        requestsTable.on("dblclick", "tbody tr", function() {
+        requestsTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             requestDetailsButton.click();
         });
 

--- a/src/center-ui/public/javascripts/requests.js
+++ b/src/center-ui/public/javascripts/requests.js
@@ -154,13 +154,13 @@ var XROAD_REQUESTS = function() {
         var requestsTable = $("#management_requests_all");
         var requestDetailsButton = $("#request_details");
 
-        requestsTable.on("click", "tbody tr", function(ev) {
+        requestsTable
+        .on("click", "tbody tr", function(ev) {
             if (oManagementRequests.setFocus(0, ev.target.parentNode)) {
                 $(".request-action").enable();
             }
-        });
-
-        requestsTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+        })
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             requestDetailsButton.click();
         });
 

--- a/src/center-ui/public/javascripts/requests.js
+++ b/src/center-ui/public/javascripts/requests.js
@@ -134,11 +134,13 @@ var XROAD_REQUESTS = function() {
 
     function openRequestDetails() {
         var request = oManagementRequests.getFocusData();
-        var updateTablesCallback = function() {
-            updateTable();
-        }
+        if (request && request.hasOwnProperty("id")) {
+            var updateTablesCallback = function() {
+                updateTable();
+            }
 
-        XROAD_REQUEST_EDIT.open(request, updateTablesCallback);
+            XROAD_REQUEST_EDIT.open(request, updateTablesCallback);
+        }
     }
 
     function getTranslatedRequestType(rawRequestType) {
@@ -152,19 +154,20 @@ var XROAD_REQUESTS = function() {
         focusInput();
         createTranslationAndValueMappings();
 
-        $("#management_requests_all tbody td[class!=dataTables_empty]")
-                .live("click",function(ev) {
+        var requestsTable = $("#management_requests_all");
+        var requestDetailsButton = $("#request_details");
+
+        requestsTable.on("click", "tbody tr", function(ev) {
             if (oManagementRequests.setFocus(0, ev.target.parentNode)) {
                 $(".request-action").enable();
             }
         });
 
-        $("#management_requests_all tbody tr[class!=dataTables_empty]")
-                .live("dblclick", function() {
-            openRequestDetails();
+        requestsTable.on("dblclick", "tbody tr", function() {
+            requestDetailsButton.click();
         });
 
-        $("#request_details").click(function() {
+        requestDetailsButton.click(function() {
             openRequestDetails();
         });
     });

--- a/src/center-ui/public/javascripts/securityservers.js
+++ b/src/center-ui/public/javascripts/securityservers.js
@@ -56,20 +56,23 @@ var XROAD_SECURITYSERVERS = function() {
         enableActions();
         focusInput();
 
-        $("#securityservers tbody td[class!=dataTables_empty]")
-                .live("click",function(ev) {
+        var serversTable = $("#securityservers");
+
+        serversTable.on("click", "tbody tr", function(ev) {
             if (oSecurityServers.setFocus(0, ev.target.parentNode)) {
                 $(".securityserver-action").enable();
             }
         });
 
-        $("#securityservers tbody tr")
-                .unbind("dblclick").live("dblclick", function() {
-            XROAD_SECURITYSERVER_EDIT.open(oSecurityServers.getFocusData(), true);
+        serversTable.on("dblclick", "tbody tr", function() {
+            $("#securityserver_edit").click();
         });
 
         $("#securityserver_edit").click(function() {
-            XROAD_SECURITYSERVER_EDIT.open(oSecurityServers.getFocusData(), true);
+            var itemData = oSecurityServers.getFocusData();
+            if (itemData && itemData.hasOwnProperty("owner_name")) {
+                XROAD_SECURITYSERVER_EDIT.open(oSecurityServers.getFocusData(), true);
+            }
         });
     });
 

--- a/src/center-ui/public/javascripts/securityservers.js
+++ b/src/center-ui/public/javascripts/securityservers.js
@@ -58,13 +58,13 @@ var XROAD_SECURITYSERVERS = function() {
 
         var serversTable = $("#securityservers");
 
-        serversTable.on("click", "tbody tr", function(ev) {
+        serversTable
+        .on("click", "tbody tr", function(ev) {
             if (oSecurityServers.setFocus(0, ev.target.parentNode)) {
                 $(".securityserver-action").enable();
             }
-        });
-
-        serversTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+        })
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             $("#securityserver_edit").click();
         });
 

--- a/src/center-ui/public/javascripts/securityservers.js
+++ b/src/center-ui/public/javascripts/securityservers.js
@@ -64,15 +64,12 @@ var XROAD_SECURITYSERVERS = function() {
             }
         });
 
-        serversTable.on("dblclick", "tbody tr", function() {
+        serversTable.on("dblclick", "tbody td[class!=dataTables_empty]", function() {
             $("#securityserver_edit").click();
         });
 
         $("#securityserver_edit").click(function() {
-            var itemData = oSecurityServers.getFocusData();
-            if (itemData && itemData.hasOwnProperty("owner_name")) {
-                XROAD_SECURITYSERVER_EDIT.open(oSecurityServers.getFocusData(), true);
-            }
+            XROAD_SECURITYSERVER_EDIT.open(oSecurityServers.getFocusData(), true);
         });
     });
 

--- a/src/center-ui/public/javascripts/tsps.js
+++ b/src/center-ui/public/javascripts/tsps.js
@@ -31,12 +31,12 @@ var XROAD_TSPS = function() {
 
 
 
-        tspsTable.on("click", "tbody tr", function(ev) {
+        tspsTable
+        .on("click", "tbody tr", function(ev) {
             oTsps.setFocus(0, this);
             enableActions();
-        });
-
-        tspsTable.on("dblclick", "tbody td[class!=dataTables_empty]", function(ev) {
+        })
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function(ev) {
             $("#tsp_details").click();
         });
     }

--- a/src/center-ui/public/javascripts/tsps.js
+++ b/src/center-ui/public/javascripts/tsps.js
@@ -36,7 +36,7 @@ var XROAD_TSPS = function() {
             enableActions();
         });
 
-        tspsTable.on("dblclick", "tbody tr", function(ev) {
+        tspsTable.on("dblclick", "tbody td[class!=dataTables_empty]", function(ev) {
             $("#tsp_details").click();
         });
     }
@@ -61,17 +61,14 @@ var XROAD_TSPS = function() {
             if (!can("view_approved_tsa_details")) {
                 return;
             }
-
             var selected = oTsps.getFocusData();
-            if (selected && selected.hasOwnProperty("id")) {
-                var params = {
-                    tsp_id: selected.id
-                };
+            var params = {
+                tsp_id: selected.id
+            };
 
-                XROAD_URL_AND_CERT_DIALOG.openEditDialog(
-                    "tsp", _("tsps.edit_existing"), false,
-                    selected.url, true, params);
-            }
+            XROAD_URL_AND_CERT_DIALOG.openEditDialog(
+                "tsp", _("tsps.edit_existing"), false,
+                selected.url, true, params);
         });
 
         $("#tsp_delete").click(function() {

--- a/src/center-ui/public/javascripts/tsps.js
+++ b/src/center-ui/public/javascripts/tsps.js
@@ -17,22 +17,26 @@ var XROAD_TSPS = function() {
         opts.fnDrawCallback = function() {
             XROAD_CENTERUI_COMMON.updateRecordsCount("tsps");
             enableActions();
-        }
+        };
 
         opts.bScrollInfinite = true;
         opts.sAjaxSource = action("tsps_refresh");
 
         opts.aaSorting = [ [2,'desc'] ];
 
-        oTsps = $('#tsps').dataTable(opts);
+        var tspsTable = $("#tsps");
+
+        oTsps = tspsTable.dataTable(opts);
         oTsps.fnSetFilteringDelay(600);
 
-        $("#tsps tbody tr").live("click", function(ev) {
+
+
+        tspsTable.on("click", "tbody tr", function(ev) {
             oTsps.setFocus(0, this);
             enableActions();
         });
 
-        $("#tsps tbody tr").live("dblclick", function(ev) {
+        tspsTable.on("dblclick", "tbody tr", function(ev) {
             $("#tsp_details").click();
         });
     }
@@ -59,13 +63,15 @@ var XROAD_TSPS = function() {
             }
 
             var selected = oTsps.getFocusData();
-            var params = {
-                tsp_id: selected.id
-            };
+            if (selected && selected.hasOwnProperty("id")) {
+                var params = {
+                    tsp_id: selected.id
+                };
 
-            XROAD_URL_AND_CERT_DIALOG.openEditDialog(
-                "tsp", _("tsps.edit_existing"), false,
-                selected.url, true, params);
+                XROAD_URL_AND_CERT_DIALOG.openEditDialog(
+                    "tsp", _("tsps.edit_existing"), false,
+                    selected.url, true, params);
+            }
         });
 
         $("#tsp_delete").click(function() {

--- a/src/proxy-ui/public/javascripts/clients.js
+++ b/src/proxy-ui/public/javascripts/clients.js
@@ -568,20 +568,21 @@
         opts.aaSortingFixed = [[4,'desc']];
         opts.aaSorting = [[1,'asc']];
 
-        oClients = $("#clients").dataTable(opts);
+        var clientsTable = $("#clients");
 
-        $("#clients tbody tr").live("dblclick", function() {
-            var clientData = oClients.fnGetData(this);
+        oClients = clientsTable.dataTable(opts);
+
+        clientsTable
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function() {
+            var clientData = oClients.getFocusData();
             if (clientData.can_view_client_details_dialog) {
-                openClientDetails(oClients.fnGetData(this), "#details_tab");
+                openClientDetails(clientData, "#details_tab");
             }
-        });
-
-        $('#clients').on('click', 'tbody tr', function() {
+        })
+        .on('click', 'tbody tr', function() {
             oClients.setFocus(0, this);
-        });
-
-        $("#clients").on("click", ".tableitem-actions li", function() {
+        })
+        .on("click", ".tableitem-actions li", function() {
             oClients.setFocus(0, $(this).closest("tr"));
             openClientDetails(oClients.getFocusData(), $(this).data("tab"));
         });
@@ -598,9 +599,10 @@
             { "mData": "subsystem_code", "mRender" : util.escape }
         ];
 
-        oClientsGlobal = $("#clients_global").dataTable(opts);
+        var globalTable = $("#clients_global");
+        oClientsGlobal = globalTable.dataTable(opts);
 
-        $("#clients_global tbody tr").live("click", function() {
+        globalTable.on("click", "tbody tr", function() {
             oClientsGlobal.setFocus(0, this);
             enableActions();
         });

--- a/src/proxy-ui/public/javascripts/groups.js
+++ b/src/proxy-ui/public/javascripts/groups.js
@@ -384,15 +384,17 @@
         ];
         opts.asRowId = ["code"];
 
-        oGroups = $("#groups").dataTable(opts);
+        var groupTable = $("#groups");
 
-        $("#groups tbody tr").live("click", function() {
+        oGroups = groupTable.dataTable(opts);
+
+        groupTable
+        .on("click", "tbody tr", function() {
             oGroups.setFocus(0, this);
             enableGroupsActions();
-        });
-
-        $("#groups tbody tr").live("dblclick", function() {
-            oGroups.setFocus(0, this);
+        })
+        .on("dblclick", "tbody td[class!=dataTables_empty]", function(ev) {
+            oGroups.setFocus(0, ev.target.parentNode);
             enableGroupsActions();
             $("#group_details").click();
         });

--- a/src/proxy-ui/public/javascripts/keys.js
+++ b/src/proxy-ui/public/javascripts/keys.js
@@ -339,7 +339,10 @@ function initDialogs() {
         ]
     });
 
-    $(document).on("dblclick", ".token", function() {
+    var keyTable = $("#keys");
+
+    keyTable
+    .on("dblclick", ".token", function() {
         var row = $(this).closest("tr").get(0);
         var params = {
             token_id: row.dataset.id
@@ -349,9 +352,8 @@ function initDialogs() {
             $("#token_details_dialog .dialog-body").html(data);
             $("#token_details_dialog").dialog("open");
         }, "html");
-    });
-
-    $(document).on("dblclick", ".key", function() {
+    })
+    .on("dblclick", ".key", function() {
         var row = $(this).closest("tr").get(0);
         var params = {
             token_id: row.dataset.parentId,
@@ -362,9 +364,8 @@ function initDialogs() {
             $("#key_details_dialog .dialog-body").html(data);
             $("#key_details_dialog").dialog("open");
         }, "html");
-    });
-
-    $(document).on("dblclick", ".cert-active , .cert-inactive", function() {
+    })
+    .on("dblclick", ".cert-active , .cert-inactive", function() {
         var row = $(this).closest("tr").get(0);
         var data = oKeys.fnGetData(row);
 


### PR DESCRIPTION
This pull request contains fixes for click and double click event handling for various tables in both center-ui and proxy-ui: 
* deprecated uses of JQuery functions `unbind` and `live` relating directly to changed functionality have been replaced with more appropriate uses of `off` and `on`. 
* some of the document-bound event handling delegation has been moved directly to the related table element in order to reduce bubbling distance. 
* the root issue has been solved by detecting empty `td` -elements by the class `dataTables_empty` and preventing events originating from them from causing any reaction at the delegated event handler.

Center-ui views affected:
- Members
- Security Servers
- Global Groups
- Central Services
- Certification Services
- Timestamping Services
- Management Requests
- System Settings (Edit Management Services)

Proxy-ui views affected:
- Security Server Clients
- Keys and Certificates