### PR TITLE
PVAYLADEV-918 fix broken RHEL installation and wrong repo URL

### DIFF
--- a/ansible/roles/init-lxd/tasks/main.yml
+++ b/ansible/roles/init-lxd/tasks/main.yml
@@ -1,4 +1,3 @@
-
 - name: Ensure a started container
   with_inventory_hostnames: all:!lxd-servers
   lxd_container:
@@ -13,4 +12,18 @@
     profiles: ["default"]
     wait_for_ipv4_addresses: true
     timeout: 600
-    
+
+- name: Check if Python2 is installed in container
+  with_inventory_hostnames: all:!lxd-servers
+  delegate_to: "{{item}}"
+  raw: dpkg -s python
+  register: python_check_is_installed
+  failed_when: python_check_is_installed.rc not in [0,1]
+  changed_when: false
+
+- name: Install Python2 in container
+  delegate_to: "{{item.item}}"
+  raw: apt-get update && apt-get install -y python
+  when: item.rc == 1
+  with_items:
+    - "{{python_check_is_installed.results}}"

--- a/ansible/roles/xroad-base/tasks/rhel.yml
+++ b/ansible/roles/xroad-base/tasks/rhel.yml
@@ -3,6 +3,9 @@
   yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 
+- name: force yum to accept ca-key which signs repodata
+  shell: yum -y makecache fast
+
 - name: xroad repo
   template:
     src: "palveluvayla.repo.j2"

--- a/ansible/roles/xroad-base/tasks/rhel.yml
+++ b/ansible/roles/xroad-base/tasks/rhel.yml
@@ -3,7 +3,7 @@
   yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 
-- name: force yum to accept ca-key which signs repodata
+- name: try to make sure the repos. are current
   shell: yum -y makecache fast
 
 - name: xroad repo

--- a/ansible/roles/xroad-base/templates/palveluvayla.repo.j2
+++ b/ansible/roles/xroad-base/templates/palveluvayla.repo.j2
@@ -1,6 +1,6 @@
 [palveluvayla]
 name=Palveluväylä repository for RHEL7
-baseurl=http://www.nic.funet.fi/pub/csc/x-road/client/rhel7-test-current/stable
+baseurl=http://www.nic.funet.fi/pub/csc/x-road/client/rhel7-prod-current/stable
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1

--- a/ansible/roles/xroad-ss/tasks/rhel.yml
+++ b/ansible/roles/xroad-ss/tasks/rhel.yml
@@ -1,9 +1,6 @@
 ---
 - name: install xroad security server packages
-  yum:
-    name: xroad-securityserver-fi
-    state: present
-    update_cache: yes
+  command: yum -y install xroad-securityserver-fi
 
 - name: add xroad admin user
   command: "xroad-add-admin-user {{ xroad_ui_user }}"

--- a/ansible/xroad_dev.yml
+++ b/ansible/xroad_dev.yml
@@ -15,16 +15,6 @@
     - compile
     
 - hosts: ss-servers, cs-servers, cp-servers
-  become: yes
-  become_user: root
-  gather_facts: no
-  pre_tasks:
-    - name: 'Install python2'
-      raw: apt-get -y install python
-  tags:
-    - init
-
-- hosts: ss-servers, cs-servers, cp-servers
   roles:
     - packages-to-local-repo
   tags:

--- a/ansible/xroad_dev_partial.yml
+++ b/ansible/xroad_dev_partial.yml
@@ -19,16 +19,6 @@
   tags: 
     - compile
 
-- hosts: ss-servers, cs-servers, cp-servers
-  become: yes
-  become_user: root
-  gather_facts: no
-  pre_tasks:
-    - name: 'Install python2'
-      raw: apt-get -y install python
-  tags:
-    - init
-
 - hosts: cs-servers
   vars_files:
     - common_modules.yml

--- a/ansible/xroad_init.yml
+++ b/ansible/xroad_init.yml
@@ -8,16 +8,6 @@
   tags:
     - init
     
-- hosts: ss-servers, cs-servers, cp-servers, ca-servers
-  become: yes
-  become_user: root
-  gather_facts: no
-  pre_tasks:
-    - name: 'Install python2'
-      raw: apt-get -y install python
-  tags:
-    - init
-    
 - hosts: cs-servers
   become: yes
   become_user: root
@@ -33,13 +23,6 @@
     - xroad-cp
   tags:
     - cp
-
-- hosts: ss-servers, cs-servers, cp-servers, ca-servers
-  become: yes
-  become_user: root
-  gather_facts: no
-  pre_tasks:
-    - raw: apt-get -y install python
 
 - hosts: ss-servers
   become: yes


### PR DESCRIPTION
Changed how python2 is installed to LXD hosts, since the old way broke RHEL installations. Corrected RHEL repo URL.

https://jira.csc.fi/browse/PVAYLADEV-918