### PR TITLE
PVAYLADEV-861: Migration for modified configuration properties to ensure backwards compatibility

### DIFF
--- a/src/packages/xroad/debian/xroad-proxy.postinst
+++ b/src/packages/xroad/debian/xroad-proxy.postinst
@@ -142,6 +142,27 @@ case "$1" in
  ;;
 esac
 
+#parameters:
+#1 file_path
+#2 old_section
+#3 old_key
+#4 new_section
+#5 new_key
+function migrate_conf_value {
+    MIGRATION_VALUE=$(crudini --get $1 $2 $3 2>/dev/null)
+    if [ ${MIGRATION_VALUE} ];
+        then
+            crudini --set $1 $4 $5 ${MIGRATION_VALUE}
+            echo Configuration migration: $2.$3 "->" $4.$5
+            crudini --del $1 $2 $3
+    fi
+}
+
+#migrating possible local configuration for modified configuration values (for version 6.17.0)
+migrate_conf_value /etc/xroad/conf.d/local.ini proxy ocsp-cache-path signer ocsp-cache-path
+migrate_conf_value /etc/xroad/conf.d/local.ini proxy enforce-token-pin-policy signer enforce-token-pin-policy
+
+
 db_stop
 
 service rsyslog restart

--- a/src/packages/xroad/debian/xroad-proxy.postinst
+++ b/src/packages/xroad/debian/xroad-proxy.postinst
@@ -149,12 +149,12 @@ esac
 #4 new_section
 #5 new_key
 function migrate_conf_value {
-    MIGRATION_VALUE=$(crudini --get $1 $2 $3 2>/dev/null)
-    if [ ${MIGRATION_VALUE} ];
+    MIGRATION_VALUE="$(crudini --get "$1" "$2" "$3" 2>/dev/null)"
+    if [ "${MIGRATION_VALUE}" ];
         then
-            crudini --set $1 $4 $5 ${MIGRATION_VALUE}
-            echo Configuration migration: $2.$3 "->" $4.$5
-            crudini --del $1 $2 $3
+            crudini --set "$1" "$4" "$5" "${MIGRATION_VALUE}"
+            echo Configuration migration: "$2"."$3" "->" "$4"."$5"
+            crudini --del "$1" "$2" "$3"
     fi
 }
 

--- a/src/packages/xroad/redhat/SPECS/xroad-proxy.spec
+++ b/src/packages/xroad/redhat/SPECS/xroad-proxy.spec
@@ -170,6 +170,26 @@ if [ $1 -gt 1 ]; then
     rm -rf %{_localstatedir}/lib/rpm-state/%{name}
 fi
 
+#parameters:
+#1 file_path
+#2 old_section
+#3 old_key
+#4 new_section
+#5 new_key
+function migrate_conf_value {
+    MIGRATION_VALUE=$(crudini --get $1 $2 $3 2>/dev/null)
+    if [ ${MIGRATION_VALUE} ];
+        then
+            crudini --set $1 $4 $5 ${MIGRATION_VALUE}
+            echo Configuration migration: $2.$3 "->" $4.$5
+            crudini --del $1 $2 $3
+    fi
+}
+
+#migrating possible local configuration for modified configuration values (for version 6.17.0)
+migrate_conf_value /etc/xroad/conf.d/local.ini proxy ocsp-cache-path signer ocsp-cache-path
+migrate_conf_value /etc/xroad/conf.d/local.ini proxy enforce-token-pin-policy signer enforce-token-pin-policy
+
 %preun
 %systemd_preun xroad-proxy.service
 %systemd_preun xroad-confclient.service

--- a/src/packages/xroad/redhat/SPECS/xroad-proxy.spec
+++ b/src/packages/xroad/redhat/SPECS/xroad-proxy.spec
@@ -177,12 +177,12 @@ fi
 #4 new_section
 #5 new_key
 function migrate_conf_value {
-    MIGRATION_VALUE=$(crudini --get $1 $2 $3 2>/dev/null)
-    if [ ${MIGRATION_VALUE} ];
+    MIGRATION_VALUE="$(crudini --get "$1" "$2" "$3" 2>/dev/null)"
+    if [ "${MIGRATION_VALUE}" ];
         then
-            crudini --set $1 $4 $5 ${MIGRATION_VALUE}
-            echo Configuration migration: $2.$3 "->" $4.$5
-            crudini --del $1 $2 $3
+            crudini --set "$1" "$4" "$5" "${MIGRATION_VALUE}"
+            echo Configuration migration: "$2"."$3" "->" "$4"."$5"
+            crudini --del "$1" "$2" "$3"
     fi
 }
 


### PR DESCRIPTION
As per review comment, the modified configuration properties
- signer.ocsp-cache-path (formerly in proxy-section)
- signer.enforce-token-pin-policy (formerly in proxy-section)
need to have migration set up for any possible local configuration overrides present in currently installed systems. The migration scripts run after package installation will move any local configuration for these properties under the signer-section so that it is visible to the modified SystemProperties.