### PR TITLE
PVAYLADEV-1039: Added ee-metapackage to ee-variant Ansible installation

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -25,14 +25,14 @@ You determine which servers are initialized by filling in the groups
 you can leave that group empty.
 
 **Note:** Study the structure of the example host files carefully and model the group hierarchies that you wish to implement in your own
-inventory files. For example, the group `[centos-ss]` for CentOS-based security server LXD-containers is a child group to the security server group `[ss-servers]` and can be omitted entirely if you have no use for CentOS containers.
+inventory files. For example, the group `[centos-ss]` for CentOS-based security server LXD-containers is a child group to the security server group `[ss-servers]` and can be omitted entirely if you have no use for CentOS containers or are using the ee-variant.
 
 #### Variant
 
 When installing security servers, the Ansible playbooks use the configuration variable `variant`
 to select one of the available security server variants for installation. If no additional configurations have been made, the playbooks will install the `vanilla` variant. The three currently supported variants are:
 - `vanilla` - the basic non-country-specific version of X-Road
-- `ee` - the Estonian country variant
+- `ee` - the Estonian country variant, no RHEL variant package available
 - `fi` - the Finnish country variant
 
 Country variants provide country-specific configuration options and dependencies in order to suit the X-Road instances and policies of their host countries.

--- a/ansible/hosts/lxd_hosts.txt
+++ b/ansible/hosts/lxd_hosts.txt
@@ -18,7 +18,7 @@ xroad-lxd-ss2 ansible_connection=lxd
 [ss-servers:children]
 centos-ss
 
-#security servers (centos lxd containers)
+#security servers (centos lxd containers, not supported in variant ee)
 [centos-ss]
 xroad-lxd-rh-ss1 ansible_connection=lxd
 

--- a/ansible/roles/xroad-ss/defaults/main.yml
+++ b/ansible/roles/xroad-ss/defaults/main.yml
@@ -5,5 +5,5 @@ variant: vanilla
 #Defines the security server "variant package", a meta-package that delivers variant override configuration and
 #pulls other packages through dependencies. Variant denoted by the string after the last "_".
 xroad_varpkg_fi: xroad-securityserver-fi
-xroad_varpkg_ee: xroad-securityserver
+xroad_varpkg_ee: xroad-securityserver-ee
 xroad_varpkg_vanilla: xroad-securityserver

--- a/ansible/xroad_dev.yml
+++ b/ansible/xroad_dev.yml
@@ -1,6 +1,14 @@
 ---
 # This playbook compiles X-Road and installs the compiled packages to the defined host inventory
 
+- hosts: centos-ss
+  gather_facts: no
+  tasks:
+    - name: RHEL-support check
+      fail:
+        msg: "Variant '{{variant}}' does not support RHEL-servers. Adjust your variant selection or inventory"
+      when: variant == "ee"
+
 - hosts: lxd-servers
   roles:
     - init-lxd

--- a/ansible/xroad_dev.yml
+++ b/ansible/xroad_dev.yml
@@ -1,19 +1,21 @@
 ---
 # This playbook compiles X-Road and installs the compiled packages to the defined host inventory
 
-- hosts: centos-ss
-  gather_facts: no
-  tasks:
-    - name: RHEL-support check
-      fail:
-        msg: "Variant '{{variant}}' does not support RHEL-servers. Adjust your variant selection or inventory"
-      when: variant == "ee"
-
 - hosts: lxd-servers
   roles:
     - init-lxd
   tags: 
     - init
+
+- hosts: ss-servers
+  any_errors_fatal: true
+  tasks:
+    - name: RHEL-support check
+      fail:
+        msg: "Variant '{{ variant }}' does not support RHEL-servers"
+      when:
+        - variant == "ee"
+        - ansible_os_family == "RedHat"
 
 - hosts: compile-servers
   roles:

--- a/ansible/xroad_init.yml
+++ b/ansible/xroad_init.yml
@@ -1,6 +1,14 @@
 ---
 # This playbook installs an X-Road environment to the defined host inventory from a remote package repository
 
+- hosts: centos-ss
+  gather_facts: no
+  tasks:
+    - name: RHEL-support check
+      fail:
+        msg: "Variant '{{variant}}' does not support RHEL-servers. Adjust your variant selection or inventory"
+      when: variant == "ee"
+
 - hosts: lxd-servers
   roles:
     - role: init-lxd

--- a/ansible/xroad_init.yml
+++ b/ansible/xroad_init.yml
@@ -1,19 +1,21 @@
 ---
 # This playbook installs an X-Road environment to the defined host inventory from a remote package repository
 
-- hosts: centos-ss
-  gather_facts: no
+- hosts: lxd-servers
+  roles:
+    - init-lxd
+  tags:
+    - init
+
+- hosts: ss-servers
+  any_errors_fatal: true
   tasks:
     - name: RHEL-support check
       fail:
-        msg: "Variant '{{variant}}' does not support RHEL-servers. Adjust your variant selection or inventory"
-      when: variant == "ee"
-
-- hosts: lxd-servers
-  roles:
-    - role: init-lxd
-  tags:
-    - init
+        msg: "Variant '{{ variant }}' does not support RHEL-servers"
+      when:
+        - variant == "ee"
+        - ansible_os_family == "RedHat"
 
 - hosts: cs-servers
   become: yes


### PR DESCRIPTION
Contains:
- ee-metapackage now used to install security server when using ee-variant with xroad_dev or xroad_init playbooks
- xroad_dev and xroad_init playbooks now perform a check to see if trying to use RedHat-family servers with ee-variant. If an unsupported combination is detected, the playbook is aborted before any installations are attempted
- documented the lack of RedHat-support for ee-variant