### PR TITLE
Move runTransferCommand out from while loop

### DIFF
--- a/src/addons/messagelog/src/main/java/ee/ria/xroad/proxy/messagelog/LogArchiver.java
+++ b/src/addons/messagelog/src/main/java/ee/ria/xroad/proxy/messagelog/LogArchiver.java
@@ -108,7 +108,6 @@ public class LogArchiver extends UntypedActor {
             try (LogArchiveWriter archiveWriter = createLogArchiveWriter(session)) {
                 while (!records.isEmpty()) {
                     archive(archiveWriter, records);
-                    runTransferCommand(getArchiveTransferCommand());
                     recordsArchived += records.size();
 
                     //flush changes (records marked as archived) and free memory
@@ -125,6 +124,9 @@ public class LogArchiver extends UntypedActor {
 
                     records = getRecordsToBeArchived(session, maxTimestampId);
                 }
+
+                runTransferCommand(getArchiveTransferCommand());
+
             } catch (Exception e) {
                 throw new CodedException(ErrorCodes.X_INTERNAL_ERROR, e);
             }


### PR DESCRIPTION
This is to prevent running runTransferCommand for every record during archiving.

I've noticed that there's an issue where LogArchiver is attempting to transfer logs using archive-http-transporter.sh without having anything to actually transfer yet.

`~:/var/log/xroad# cat proxy.log|grep "2018-02-13 08:45" | grep -i transferring | wc -l
202`

And actually transferred files:
`[13/Feb/2018:08:45:01 +0200] "POST /archiver/?host=ss1 HTTP/1.1" 200 289 "-" "curl/7.35.0" "-"
[13/Feb/2018:08:45:57 +0200] "POST /archiver/?host=ss1 HTTP/1.1" 200 289 "-" "curl/7.35.0" "-"
[13/Feb/2018:08:46:47 +0200] "POST /archiver/?host=ss1 HTTP/1.1" 200 289 "-" "curl/7.35.0" "-"
[13/Feb/2018:08:47:32 +0200] "POST /archiver/?host=ss1 HTTP/1.1" 200 289 "-" "curl/7.35.0" "-"
[13/Feb/2018:08:48:04 +0200] "POST /archiver/?host=ss1 HTTP/1.1" 200 289 "-" "curl/7.35.0" "-"
[13/Feb/2018:08:48:32 +0200] "POST /archiver/?host=ss1 HTTP/1.1" 200 289 "-" "curl/7.35.0" "-"
[13/Feb/2018:08:49:18 +0200] "POST /archiver/?host=ss1 HTTP/1.1" 200 289 "-" "curl/7.35.0" "-"