### PR TITLE
PVAYLADEV-989:  Back-up functionality creates an incomplete back-up archive when the script produces an error

### DIFF
--- a/doc/UseCases/uc-cs_x-road_use_case_model_for_central_server_management_1.2_Y-883-6.md
+++ b/doc/UseCases/uc-cs_x-road_use_case_model_for_central_server_management_1.2_Y-883-6.md
@@ -5,7 +5,7 @@
 # X-Road: Use Case Model for Central Server Management
 **Analysis**
 
-Version: 1.3
+Version: 1.4
 19.02.2018
 <!-- 38 pages -->
 Doc. ID: UC-CS
@@ -21,8 +21,8 @@ Date       | Version | Description                                              
 21.09.2015 |  1.0    |   Editorial changes made                                                                                                                  |   Imbi Nõgisto
 08.11.2015 |  1.1    |   Renamed *Scope* element to *System*. Renamed *User* to *CS administrator*. Updated use cases CS\_07 and CS\_08. Minor corrections done. |   Riin Saarmäe
 13.12.2015 |  1.2    |   Restore clears the shared memory (UC CS\_08)                                                                                            |   Riin Saarmäe
-29.08.2017 |  1.2    |  Changed documentation type from docx to md file | Lasse Matikainen
-19.02.2018 |  1.3    |   Updated the negative case extension for backing up the central server | Tatu Repo
+29.08.2017 |  1.3    |  Changed documentation type from docx to md file | Lasse Matikainen
+19.02.2018 |  1.4    |   Updated the negative case extension for backing up the central server | Tatu Repo
 
 ## Table of Contents
 

--- a/doc/UseCases/uc-cs_x-road_use_case_model_for_central_server_management_1.2_Y-883-6.md
+++ b/doc/UseCases/uc-cs_x-road_use_case_model_for_central_server_management_1.2_Y-883-6.md
@@ -5,8 +5,8 @@
 # X-Road: Use Case Model for Central Server Management
 **Analysis**
 
-Version: 1.2
-29.08.2017
+Version: 1.3
+19.02.2018
 <!-- 38 pages -->
 Doc. ID: UC-CS
 ------------------------------------------------------
@@ -22,6 +22,7 @@ Date       | Version | Description                                              
 08.11.2015 |  1.1    |   Renamed *Scope* element to *System*. Renamed *User* to *CS administrator*. Updated use cases CS\_07 and CS\_08. Minor corrections done. |   Riin Saarmäe
 13.12.2015 |  1.2    |   Restore clears the shared memory (UC CS\_08)                                                                                            |   Riin Saarmäe
 29.08.2017 |  1.2    |  Changed documentation type from docx to md file | Lasse Matikainen
+19.02.2018 |  1.3    |   Updated the negative case extension for backing up the central server | Tatu Repo
 
 ## Table of Contents
 
@@ -432,9 +433,10 @@ configuration.
 **Extensions**:
 
 - 3a. Backing up the central server configuration failed.
-    - 3a.1. System displays the error message “Error making configuration backup, script exited with status code 'X'” (where “X” is the exit code of the backup script) and the output of the backup script.
-    - 3a.2. System logs the event “Back up configuration failed” to the audit log.
-    - 3a.3. Use case terminates.
+    - 3a.1  Backup script produces an error code that prompts the error handling to remove any incomplete backup archives
+    - 3a.2. System displays the error message “Error making configuration backup, script exited with status code 'X'” (where “X” is the exit code of the backup script) and the output of the backup script.
+    - 3a.3. System logs the event “Back up configuration failed” to the audit log.
+    - 3a.4. Use case terminates.
 
 **Related information**:
 

--- a/doc/UseCases/uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md
+++ b/doc/UseCases/uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md
@@ -4,8 +4,8 @@
 # X-Road: Use Case Model for Security Server Management
 **Analysis**
 
-Version: 1.5
-29.08.2017
+Version: 1.6
+19.02.2018
 <!-- 49 pages -->
 Doc. ID: UC-SS
 
@@ -28,6 +28,7 @@ Date       | Version | Description                                              
 30.11.2015 | 1.3     | Use cases updated according to system developments. | Meril Vaht
 16.12.2015 | 1.4     | UC SS\_18, UC SS\_19, UC SS\_20, UC SS\_29, UC SS\_30, UC SS\_31, UC SS\_34, UC SS\_35, UC SS\_38, UC SS\_39 updated. UC SS\_42 added. Editorial changes made. | Meril Vaht
 29.08.2017 | 1.5     | Changed documentation type from docx to md file |   Lasse Matikainen
+19.02.2018 | 1.6     | Updated the negative case extension for backing up the central server | Tatu Repo
 
 <!-- tocstop -->
 
@@ -813,9 +814,10 @@ configuration.
 **Extensions**:
 
 - 3a. Backing up the security server configuration failed.
-    - 3a.1. System displays the error message “Error making configuration backup, script exited with status code 'X'” (where “X” is the exit code of the backup script) and the output of the backup script.
-    - 3a.2. System logs the event “Back up configuration failed” to the audit log.
-    - 3a.3. Use case terminates.
+    - 3a.1  Backup script produces an error code that prompts the error handling to remove any incomplete backup archives
+    - 3a.2. System displays the error message “Error making configuration backup, script exited with status code 'X'” (where “X” is the exit code of the backup script) and the output of the backup script.
+    - 3a.3. System logs the event “Back up configuration failed” to the audit log.
+    - 3a.4. Use case terminates.
 
 **Related information**:
 

--- a/src/packages/xroad/base/usr/share/xroad/scripts/_backup_xroad.sh
+++ b/src/packages/xroad/base/usr/share/xroad/scripts/_backup_xroad.sh
@@ -37,6 +37,8 @@ create_backup_tarball () {
   echo "CREATING TAR ARCHIVE TO ${BACKUP_FILENAME}"
   tar --create -v --label "${TARBALL_LABEL}" --file ${BACKUP_FILENAME} --exclude="/etc/xroad/postgresql" ${BACKED_UP_PATHS}
   if [ $? != 0 ] ; then
+    echo "Removing incomplete backup archive"
+    rm -v ${BACKUP_FILENAME}
     die "Creating a backup file to ${BACKUP_FILENAME} failed!" \
         "Please check the error messages and fix them before trying again!"
   fi


### PR DESCRIPTION
Includes:
- Back-up script now attempts to remove the incomplete back-up archive if tar-command exit code != 0
  * remedies the underlying issue of tar-command creating an archive even if target contents are not accessible (i.e. an incomplete backup)
  * affects both central and security servers
  * affects both GUI back-ups and command line back-ups (same base scripting)
- Use case documentation updated to reflect changed functionality
