### PR TITLE
PVAYLADEV-984: Unified remaining individual terms and abbreviations -sections into the terms document

### DIFF
--- a/doc/Architecture/arc-cp_x-road_configuration_proxy_architecture.md
+++ b/doc/Architecture/arc-cp_x-road_configuration_proxy_architecture.md
@@ -6,8 +6,8 @@
 # X-Road: Configuration Proxy Architecture
 **Technical Specification**
 
-Version: 1.4
- 19.01.2018
+Version: 1.5  
+02.03.2018
 <!-- 1 pages -->
  Doc. ID: ARC-CP
 
@@ -25,6 +25,7 @@ Version: 1.4
  21.10.2015 | 1.2     | SSCD and passwordstore related information added                | Ilja Kromonov
  24.02.2017 | 1.3     | Converted to Github flavoured Markdown, added license text, adjusted tables for better output in PDF | Toomas Mölder
  19.01.2018 | 1.4     | Matrix of technologies moved to ARC-TEC-file and chapters reordered | Antti Luoma 
+ 02.03.2018 | 1.5     | Moved terms and abbreviations to terms document                 | Tatu Repo
 
 ## Table of Contents
 
@@ -71,21 +72,22 @@ The configuration proxy can be configured to mediate several global configuratio
 
 ### 1.2 Terms and Abbreviations
 
--   **Configuration proxy instance** – a process within the configuration proxy that deals with distributing the global configuration files of a specific X-Road instance.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 
 ### 1.3 References
 
-1. <a id="Ref_ARC-G" class="anchor"></a>\[ARC-G\] Cybernetica AS. X-Road Architecture.
+1. <a id="Ref_ARC-G" class="anchor"></a>\[ARC-G\] Cybernetica AS. X-Road Architecture. Document ID: [ARC-G](arc-g_x-road_arhitecture.md).
 
-2. <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] Cybernetica AS. X-Road: Protocol for Downloading Configuration.
+2. <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] Cybernetica AS. X-Road: Protocol for Downloading Configuration. Document ID: [PR-GCONF](../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md).
 
 3. <a id="Ref_PKCS11" class="anchor"></a>\[PKCS11\] Cryptographic Token Interface Standard. RSA Laboratories, PKCS\#11.
 
-4. <a id="Ref_UG-CP" class="anchor"></a>\[UG-CP\] Cybernetica AS. X-Road v6 Configuration Proxy Manual.
+4. <a id="Ref_UG-CP" class="anchor"></a>\[UG-CP\] Cybernetica AS. X-Road v6 Configuration Proxy Manual. Document ID: [UG-CP](../Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md).
 
-5. <a id="Ref_ARC-TEC" class="anchor"></a>\[ARC-TEC\] X-Road technologies.
+5. <a id="Ref_ARC-TEC" class="anchor"></a>\[ARC-TEC\] X-Road technologies. Document ID: [ARC-TEC](arc-tec_x-road_technologies.md).
 
+6. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Component View
 

--- a/doc/Architecture/arc-cs_x-road_central_server_architecture.md
+++ b/doc/Architecture/arc-cs_x-road_central_server_architecture.md
@@ -6,8 +6,8 @@
 # X-Road: Central Server Architecture
 **Technical Specification**
 
-Version: 2.3
-19.01.2018
+Version: 2.4
+02.03.2018
 <!-- 12 pages -->
 Doc. ID: ARC-CS
 
@@ -31,6 +31,7 @@ Doc. ID: ARC-CS
  21.10.2015 | 2.1     | SSCD and password store related information added               | Ilja Kromonov
  24.02.2017 | 2.2     | Converted to Github flavoured Markdown, added license text, adjusted tables for better output in PDF | Toomas Mölder
  19.01.2018 | 2.3     | Matrix of technologies moved to ARC-TEC-file and chapters reordered | Antti Luoma 
+ 02.03.2018 | 2.4     | Moved terms and abbreviations into the terms document           | Tatu Repo
 
 ## Table of Contents
 
@@ -88,33 +89,27 @@ In addition to configuration distribution, the central server provides interface
 
 ### 1.2 Terms and Abbreviations
 
-**HSM** Hardware Security Module
-
-**OCSP** On-line Certificate Status Protocol
-
-**RPC** Remote Procedure Call
-
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
-1. <a id="Ref_ARC-G" class="anchor"></a>\[ARC-G\] Cybernetica AS. X-Road Architecture.
+1. <a id="Ref_ARC-G" class="anchor"></a>\[ARC-G\] Cybernetica AS. X-Road Architecture. Document ID: [ARC-G](arc-g_x-road_arhitecture.md).
 
-2. <a id="Ref_DM-CS" class="anchor"></a>\[DM-CS\] Cybernetica AS. X-Road: Central Server Configuration.
+2. <a id="Ref_DM-CS" class="anchor"></a>\[DM-CS\] Cybernetica AS. X-Road: Central Server Configuration. Document ID: [DM-CS](../DataModels/dm-cs_x-road_central_server_configuration_data_model.md).
 
-3. <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] Cybernetica AS. X-Road: Protocol for Downloading Configuration.
+3. <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] Cybernetica AS. X-Road: Protocol for Downloading Configuration. Document ID: [PR-GCONF](../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md).
 
-4. <a id="Ref_PR-MANAGE" class="anchor"></a>\[PR-MANAGE\] Cybernetica AS. X-Road: Management Services Protocol.
+4. <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Profile of Messages. Document ID: [PR-MESS](../Protocols/pr-mess_x-road_message_protocol.md).
 
-5. <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Profile of Messages.
+5. <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\] Cybernetica AS. X-Road: Management Services Protocol. Document ID: [PR-MSERV](../Protocols/pr-mserv_x-road_protocol_for_management_services.md).
 
-6. <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\] Cybernetica AS. X-Road: Management Services Protocol.
+6. <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] Cybernetica AS. X-Road: Audit log events.
 
-7. <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] Cybernetica AS. X-Road: Audit log events.
+7. <a id="Ref_PKCS11" class="anchor"></a>\[PKCS11\] Cryptographic Token Interface Standard. RSA Laboratories, PKCS\#11.
 
-8. <a id="Ref_PKCS11" class="anchor"></a>\[PKCS11\] Cryptographic Token Interface Standard. RSA Laboratories, PKCS\#11.
+8. <a id="Ref_ARC-TEC" class="anchor"></a>\[ARC-TEC\] X-Road technologies. Document ID: [ARC-TEC](arc-tec_x-road_technologies.md).
 
-9. <a id="Ref_ARC-TEC" class="anchor"></a>\[ARC-TEC\] X-Road technologies.
-
+9. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Component View
 

--- a/doc/Architecture/arc-cs_x-road_central_server_architecture.md
+++ b/doc/Architecture/arc-cs_x-road_central_server_architecture.md
@@ -6,7 +6,7 @@
 # X-Road: Central Server Architecture
 **Technical Specification**
 
-Version: 2.4
+Version: 2.4  
 02.03.2018
 <!-- 12 pages -->
 Doc. ID: ARC-CS

--- a/doc/Architecture/arc-g_x-road_arhitecture.md
+++ b/doc/Architecture/arc-g_x-road_arhitecture.md
@@ -6,8 +6,8 @@
 
 **X-Road Architecture**
 
-Version: 1.6
-21.12.2017
+Version: 1.7  
+02.03.2018
 <!-- 16 pages -->
 Doc. ID: ARC-G
 
@@ -30,6 +30,7 @@ Doc. ID: ARC-G
  20.12.2016 | 1.4     | Added operational monitoring                                    | Kristo Heero
  20.02.2017 | 1.5     | Converted to Github flavoured Markdown, added license text, adjusted tables for better output in PDF | Toomas Mölder
  21.12.2017 | 1.6     | Matrix of technologies moved to arc-x-road_technologies.md and chapters reordered | Antti Luoma 
+ 02.03.2018 | 1.7     | Moved terms and abbreviations into the terms document, added terms reference and document links | Tatu Repo
 
 ## Table of Contents
 
@@ -39,7 +40,8 @@ Doc. ID: ARC-G
 - [1 Introduction](#1-introduction)
   * [1.1 Overview](#11-overview)
   * [1.2 Design Goals](#12-design-goals)
-  * [1.3 References](#13-references)
+  * [1.3 Terms and abbreviations](#13-terms-and-abbreviations)
+  * [1.4 References](#14-references)
 - [2 System Components](#2-system-components)
   * [2.1 Central Server](#21-central-server)
   * [2.2 Security Server](#22-security-server)
@@ -105,18 +107,21 @@ The following list contains main design goals and design decisions of the X-Road
 
 -   **Two-level authentication** – X-Road core handles authentication and access control on the organization level. End-user authentication is performed by information system of the service client.
 
+## 1.3 Terms and abbreviations
 
-### 1.3 References
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
-1.  <a id="Ref_ARC-CP" class="anchor"></a>\[ARC-CP\] X-Road: Configuration Proxy Architecture. Cybernetica AS.
+### 1.4 References
 
-2.  <a id="Ref_ARC-CS" class="anchor"></a>\[ARC-CS\] X-Road: Central Server Architecture. Cybernetica AS.
+1.  <a id="Ref_ARC-CP" class="anchor"></a>\[ARC-CP\] X-Road: Configuration Proxy Architecture. Cybernetica AS. Document ID: [ARC-CP](arc-cp_x-road_configuration_proxy_architecture.md).
 
-3.  <a id="Ref_ARC-SS" class="anchor"></a>\[ARC-SS\] X-Road: Security Server Architecture. Cybernetica AS.
+2.  <a id="Ref_ARC-CS" class="anchor"></a>\[ARC-CS\] X-Road: Central Server Architecture. Cybernetica AS. Document ID: [ARC-CS](arc-cs_x-road_central_server_architecture.md).
 
-4. <a id="Ref_ARC-MA" class="anchor"></a>\[ARC-MA\] X-Road: Monitoring Architecture
+3.  <a id="Ref_ARC-SS" class="anchor"></a>\[ARC-SS\] X-Road: Security Server Architecture. Cybernetica AS. Document ID: [ARC-SS](arc-ss_x-road_security_server_architecture.md).
 
-5.  <a id="Ref_ARC-OPMOND" class="anchor"></a>\[ARC-OPMOND\] X-Road: Operational Monitoring Daemon Architecture. Cybernetica AS.
+4.  <a id="Ref_ARC-ENVMON" class="anchor"></a>\[ARC-ENVMON\] X-Road: Monitoring Architecture. Document ID: [ARC-ENVMON](../EnvironmentalMonitoring/Monitoring-architecture.md).
+
+5.  <a id="Ref_ARC-OPMOND" class="anchor"></a>\[ARC-OPMOND\] X-Road: Operational Monitoring Daemon Architecture. Cybernetica AS. Document ID: [ARC-OPMOND](../OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md).
 
 6.  <a id="Ref_BATCH-TS" class="anchor"></a>\[BATCH-TS\] Freudenthal, Margus. Using Batch Hashing for Signing and Time-Stamping. Cybernetica Research Reports, T-4-20, 2013.
 
@@ -126,29 +131,31 @@ The following list contains main design goals and design decisions of the X-Road
 
 9.  <a id="Ref_PKCS10" class="anchor"></a>\[PKCS10\] Certification Request Syntax Standard. RSA Laboratories, PKCS \#10.
 
-10. <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] X-Road: Protocol for Downloading Configuration. Cybernetica AS.
+10. <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] X-Road: Protocol for Downloading Configuration. Cybernetica AS. Document ID: [PR-GCONF](../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md).
 
-11. <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\] X-Road: Management Services Protocol. Cybernetica AS
+11. <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\] X-Road: Management Services Protocol. Cybernetica AS. Document ID: [PR-MSERV](../Protocols/pr-mserv_x-road_protocol_for_management_services.md).
 
-12.  <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] X-Road: Profile of Messages. Cybernetica AS.
+12.  <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] X-Road: Profile of Messages. Cybernetica AS. Document ID: [PR-MESS](../Protocols/pr-mess_x-road_message_protocol.md).
 
-13. <a id="Ref_PR-MESSTRANSP" class="anchor"></a>\[PR-MESSTRANSP\] X-Road: Message Transport Protocol. Cybernetica AS.
+13. <a id="Ref_PR-MESSTRANSP" class="anchor"></a>\[PR-MESSTRANSP\] X-Road: Message Transport Protocol. Cybernetica AS. Document ID: [PR-MESSTRANSP](../Protocols/pr-messtransp_x-road_message_transport_protocol_2.2_Y-743-4.docx).
 
-14. <a id="Ref_PR-META" class="anchor"></a>\[PR-META\] X-Road: Service Metadata Protocol. Cybernetica AS.
+14. <a id="Ref_PR-META" class="anchor"></a>\[PR-META\] X-Road: Service Metadata Protocol. Cybernetica AS. Document ID: [PR-META](../Protocols/pr-meta_x-road_service_metadata_protocol.md).
 
-15. <a id="Ref_PR-OPMON" class="anchor"></a>\[PR-OPMON\] X-Road: Operational Monitoring Protocol. Cybernetica AS.
+15. <a id="Ref_PR-OPMON" class="anchor"></a>\[PR-OPMON\] X-Road: Operational Monitoring Protocol. Cybernetica AS. Document ID: [PR-OPMON](../OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md).
 
-16. <a id="Ref_PR-OPMONJMX" class="anchor"></a>\[PR-OPMONJMX\] X-Road: Operational Monitoring JMX Protocol. Cybernetica AS.
+16. <a id="Ref_PR-OPMONJMX" class="anchor"></a>\[PR-OPMONJMX\] X-Road: Operational Monitoring JMX Protocol. Cybernetica AS. Document ID: [PR-OPMONJMX](../OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).
 
 17. <a id="Ref_SOAP" class="anchor"></a>\[SOAP\] Simple Object Access Protocol (SOAP) 1.1, 2000.
 
 18. <a id="Ref_TSP" class="anchor"></a>\[TSP\] Internet X.509 Public Key Infrastructure Time-Stamp Protocol (TSP). Intenet Engineering Task Force, RFC 3161, 2001.
 
-19. <a id="Ref_UG-SIGDOC" class="anchor"></a>\[UG-SIGDOC\] X-Road: Signed Document Download and Verification Manual. Cybernetica AS.
+19. <a id="Ref_UG-SIGDOC" class="anchor"></a>\[UG-SIGDOC\] X-Road: Signed Document Download and Verification Manual. Cybernetica AS. Document ID: [UG-SIGDOC](../Manuals/ug-sigdoc_x-road_signed_document_download_and_verification_manual_1.4.1_Y-883-21.docx).
 
 20. <a id="Ref_WSDL" class="anchor"></a>\[WSDL\] Web Services Description Language (WSDL) 1.1, 2001.
 
-21. <a id"Ref_ARC-TEC" class="anchor"></a>\[ARC-TEC\] X-Road technologies 18.1.2018
+21. <a id="Ref_ARC-TEC" class="anchor"></a>\[ARC-TEC\] X-Road technologies. Document ID: [ARC-TEC](arc-tec_x-road_technologies.md).
+
+22. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 
 ## 2 System Components

--- a/doc/Architecture/arc-ss_x-road_security_server_architecture.md
+++ b/doc/Architecture/arc-ss_x-road_security_server_architecture.md
@@ -6,8 +6,8 @@
 
 **Technical Specification**
 
-Version: 1.5
-19.01.2018
+Version: 1.6  
+02.03.2018
 <!-- 15 pages -->
 Doc. ID: ARC-SS
 
@@ -31,7 +31,8 @@ Doc. ID: ARC-SS
  19.12.2016 | 1.3     | Added operational monitoring                                | Kristo Heero
  20.02.2017 | 1.4     | Converted to Github flavoured Markdown, added license text, adjusted tables for better output in PDF | Toomas Mölder
  19.01.2018 | 1.5     | Matrix of technologies moved to ARC-TEC-file and chapters reordered | Antti Luoma 
-
+ 02.03.2018 | 1.6     | Moved terms and abbreviations to terms document, added terms reference and document links | Tatu Repo
+ 
 ## Table of Contents
 
 <!-- toc -->
@@ -102,55 +103,47 @@ The security server also depends on a central server, which provides the global 
 
 ### 1.2 Terms and Abbreviations
 
-**MIME** - Multipurpose Internet Mail Extensions
-
-**OCSP** - Online Certificate Status Protocol
-
-**SOAP** - Simple Object Access Protocol
-
-**TLS** - Transport Layer Security
-
-**TSP** - Time Stamp Provider
-
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
-1. <a id="Ref_ARC-G" class="anchor"></a>\[ARC-G\] Cybernetica AS. X-Road Architecture.
+1. <a id="Ref_ARC-G" class="anchor"></a>\[ARC-G\] Cybernetica AS. X-Road Architecture. Document ID: [ARC-G](arc-g_x-road_arhitecture.md).
 
-2. <a id="Ref_ARC-OPMOND" class="anchor"></a>\[ARC-OPMOND\] Cybernetica AS. X-Road: Operational Monitoring Daemon Architecture.
+2. <a id="Ref_ARC-OPMOND" class="anchor"></a>\[ARC-OPMOND\] Cybernetica AS. X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md).
 
 3. <a id="Ref_BATCH-TS" class="anchor"></a>\[BATCH-TS\] Freudenthal, Margus. Using Batch Hashing for Signing and Time-Stamping. Cybernetica Research Reports, T-4-20, 2013.
 
-4. <a id="Ref_DM-SS" class="anchor"></a>\[DM-SS\] Cybernetica AS. X-Road: Security Server Configuration.
+4. <a id="Ref_DM-SS" class="anchor"></a>\[DM-SS\] Cybernetica AS. X-Road: Security Server Configuration. Document ID: [DM-SS](../DataModels/dm-ss_x-road_security_server_configuration._data_model_1.2_Y-883-12.docx).
 
-5. <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] Cybernetica AS. X-Road: Audit log events.
+5. <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] Cybernetica AS. X-Road: Audit log events. Document ID: [SPEC-AL](spec-al_x-road_audit_log_events_1.7_Y-883-17.docx).
 
 6. <a id="Ref_OCSP" class="anchor"></a>\[OCSP\] X.509 Internet Public Key Infrastructure Online Certificate Status Protocol - OCSP. Internet Engineering Task Force, RFC 6960, 2013.
 
 7. <a id="Ref_PKCS11" class="anchor"></a>\[PKCS11\] Cryptographic Token Interface Standard. RSA Laboratories, PKCS\#11.
 
-8. <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] Cybernetica AS. X-Road: Protocol for Downloading Configuration.
+8. <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] Cybernetica AS. X-Road: Protocol for Downloading Configuration. Document ID: [PR-GCONF](../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md).
 
-9. <a id="Ref_PR-MANAGE" class="anchor"></a>\[PR-MANAGE\] Cybernetica AS. X-Road: Management Services Protocol.
+9. <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\] Cybernetica AS. X-Road: Management Services Protocol. Document ID: [PR-MSERV](../Protocols/pr-mserv_x-road_protocol_for_management_services.md).
 
-10. <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Profile of Messages.
+10. <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Profile of Messages. Document ID: [PR-MESS](../Protocols/pr-mess_x-road_message_protocol.md).
 
-11. <a id="Ref_PR-MESSTRANSP" class="anchor"></a>\[PR-MESSTRANSP\] Cybernetica AS. X-Road: Message Transport Protocol.
+11. <a id="Ref_PR-MESSTRANSP" class="anchor"></a>\[PR-MESSTRANSP\] Cybernetica AS. X-Road: Message Transport Protocol. Document ID: [PR-MESSTRANSP](../Protocols/pr-messtransp_x-road_message_transport_protocol_2.2_Y-743-4.docx).
 
-12. <a id="Ref_PR-META" class="anchor"></a>\[PR-META\] Cybernetica AS. X-Road: Service Metadata Protocol.
+12. <a id="Ref_PR-META" class="anchor"></a>\[PR-META\] Cybernetica AS. X-Road: Service Metadata Protocol. Document ID: [PR-META](../Protocols/pr-meta_x-road_service_metadata_protocol.md).
 
-13. <a id="Ref_PR-OPMON" class="anchor"></a>\[PR-OPMON\] Cybernetica AS. X-Road: Operational Monitoring Protocol.
+13. <a id="Ref_PR-OPMON" class="anchor"></a>\[PR-OPMON\] Cybernetica AS. X-Road: Operational Monitoring Protocol. Document ID: [PR-OPMON](../OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md).
 
 14. <a id="Ref_TSP" class="anchor"></a>\[TSP\] Internet X.509 Public Key Infrastructure Time-Stamp Protocol (TSP). Intenet Engineering Task Force, RFC 3161, 2001.
 
-15. <a id="Ref_UG-SIGDOC" class="anchor"></a>\[UG-SIGDOC\] Cybernetica AS. X-Road: Signed Document Download and Verification Manual.
+15. <a id="Ref_UG-SIGDOC" class="anchor"></a>\[UG-SIGDOC\] Cybernetica AS. X-Road: Signed Document Download and Verification Manual. Document ID: [UG-SIGDOC](../Manuals/ug-sigdoc_x-road_signed_document_download_and_verification_manual_1.4.1_Y-883-21.docx).
 
-16. <a id="Ref_UC-MESS" class="anchor"></a>\[UC-MESS\] Cybernetica AS. X-Road: Member Communication Use Case Model.
+16. <a id="Ref_UC-MESS" class="anchor"></a>\[UC-MESS\] Cybernetica AS. X-Road: Member Communication Use Case Model. Document ID: [UC-MESS](../UseCases/uc-mess_x-road_member_communication_use_case_model.md).
 
-17. <a id="Ref_ARC-MA" class="anchor"></a>\[ARC-MA\] X-Road: Monitoring Architecture
+17. <a id="Ref_ARC-ENVMON" class="anchor"></a>\[ARC-ENVMON\] X-Road: Monitoring Architecture. Document ID: [ARC-ENVMON](../EnvironmentalMonitoring/Monitoring-architecture.md).
 
-18. <a id="Ref_ARC-TEC" class="anchor"></a>\[ARC-TEC\] X-Road technologies.
+18. <a id="Ref_ARC-TEC" class="anchor"></a>\[ARC-TEC\] X-Road technologies. Document ID: [ARC-TEC](arc-tec_x-road_technologies.md).
 
+19. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Component View
 
@@ -277,7 +270,7 @@ The management services are called by security servers to perform management tas
 
 The management service interface is a synchronous RPC-style interface that is required by the security server. The service is provided by central servers.
 
-The interface is described in more detail in \[[ARC-G](#Ref_ARC-G)\], \[[PR-MANGE](#Ref_PR-MANAGE)\].
+The interface is described in more detail in \[[ARC-G](#Ref_ARC-G)\], \[[PR-MSERV](#Ref_PR-MSERV)\].
 
 
 ### 3.2 Download Configuration

--- a/doc/Architecture/arc-tec_x-road_technologies.md
+++ b/doc/Architecture/arc-tec_x-road_technologies.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 1.1
+Version: 1.1  
 02.03.2018
 <!-- 3 pages -->
 Doc. ID: ARC-TEC
@@ -24,11 +24,11 @@ Doc. ID: ARC-TEC
 - [1 Introduction](#1-introduction)
   * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
   * [1.2 References](#12-references)
-- [2 Overview matrix of the X-Road technology](#1-overview-matrix-of-the-x-road-technology)
-- [3 Central server technologies](#2-central-server-technologies)
-- [4 Configuration proxy technologies](#3-configuration-proxy-technologies)
-- [5 Security server technologies](#4-security-server-technologies)
-- [6 Operational monitoring daemon technologies](#5-operational-monitoring-daemon-technologies)
+- [2 Overview matrix of the X-Road technology](#2-overview-matrix-of-the-x-road-technology)
+- [3 Central server technologies](#3-central-server-technologies)
+- [4 Configuration proxy technologies](#4-configuration-proxy-technologies)
+- [5 Security server technologies](#5-security-server-technologies)
+- [6 Operational monitoring daemon technologies](#6-operational-monitoring-daemon-technologies)
 
 <!-- tocstop -->
 

--- a/doc/Architecture/arc-tec_x-road_technologies.md
+++ b/doc/Architecture/arc-tec_x-road_technologies.md
@@ -2,8 +2,8 @@
 
 **Technical Specification**
 
-Version: 1.0
-02.02.2018
+Version: 1.1
+02.03.2018
 <!-- 3 pages -->
 Doc. ID: ARC-TEC
 
@@ -14,19 +14,21 @@ Doc. ID: ARC-TEC
  Date       | Version | Description                                                 | Author
  ---------- | ------- | ----------------------------------------------------------- | --------------------
  02.02.2018 | 1.0     | Initial version                                             | Antti Luoma
- 
+ 02.03.2018 | 1.1     | Added uniform terms and conditions reference                | Tatu Repo
 
 ## Table of Contents
 
 <!-- toc -->
 
 - [License](#license)
-- [References](#references)
-- [1 Overview matrix of the X-Road technology](#1-overview-matrix-of-the-x-road-technology)
-- [2 Central server technologies](#2-central-server-technologies)
-- [3 Configuration proxy technologies](#3-configuration-proxy-technologies)
-- [4 Security server technologies](#4-security-server-technologies)
-- [5 Operational monitoring daemon technologies](#5-operational-monitoring-daemon-technologies)
+- [1 Introduction](#1-introduction)
+  * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+  * [1.2 References](#12-references)
+- [2 Overview matrix of the X-Road technology](#1-overview-matrix-of-the-x-road-technology)
+- [3 Central server technologies](#2-central-server-technologies)
+- [4 Configuration proxy technologies](#3-configuration-proxy-technologies)
+- [5 Security server technologies](#4-security-server-technologies)
+- [6 Operational monitoring daemon technologies](#5-operational-monitoring-daemon-technologies)
 
 <!-- tocstop -->
 
@@ -34,13 +36,24 @@ Doc. ID: ARC-TEC
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/
 
-## References
+## 1 Introduction
+
+This document describes the general technology composition of X-Road components. To better illustrate the role of main technologies in X-Road, the information is collected in to several technology matrices highlighting the technology relationships between components.   
+
+## 1.1 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+
+## 1.2 References
 
 1. <a name="ARC-CP"></a>**ARC-CP** -- X-Road: Configuration Proxy Architecture. Document ID: [ARC-CP](../Architecture/arc-cp_x-road_configuration_proxy_architecture.md).  
 2. <a name="ARC-CS"></a>**ARC-CS** -- X-Road: Central Server Architecture. Document ID: [ARC-CS](../Architecture/arc-cs_x-road_central_server_architecture.md).  
 3. <a name="ARC-SS"></a>**ARC-SS** -- X-Road: Security Server Architecture. Document ID: [ARC-SS](../Architecture/arc-ss_x-road_security_server_architecture.md).
 4. <a name="ARC-OPMOND"></a>**ARC-OPMOND** -- X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md).
 5. <a name="ARC-G"></a>**ARC-G** --  X-Road Architecture. Document ID: [ARC-G](../Architecture/arc-g_x-road_arhitecture.md).   
+1. <a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+
 
 ## 1 Overview matrix of the X-Road technology
 

--- a/doc/DataModels/dm-cs_x-road_central_server_configuration_data_model.md
+++ b/doc/DataModels/dm-cs_x-road_central_server_configuration_data_model.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server Configuration Data Model
 
-Version: 1.5  
+Version: 1.6  
 Doc. ID: DM-CS
 
 | Date       | Version | Description                                             | Author             |
@@ -18,18 +18,21 @@ Doc. ID: DM-CS
 | 11.12.2015 | 1.3     | Subsystems can only be clients of security servers      | Siim Annuk         |
 | 02.02.2017 | 1.4     | Update distributed_files and convert to markdown format | Ilkka Seppälä      |
 | 05.06.2017 | 1.5     | System parameter *confSignAlgoId* replaced with *confSignDigestAlgoId* | Kristo Heero |
+| 02.03.2018 | 1.6     | Added uniform terms and conditions reference            | Tatu Repo |
 
 ## Table of Contents
 
 - [1 General](#1-general)
 	- [1.1 Preamble](#11-preamble)
-	- [1.2 Database Version](#12-database-version)
-	- [1.3 Creating, Backing Up and Restoring the Database](#13-creating-backing-up-and-restoring-the-database)
-	- [1.4 Saving Database History](#14-saving-database-history)
-	- [1.5 High Availability Support](#15-high-availability-support)
-	- [1.6 Entity-Relationship Diagram](#16-entity-relationship-diagram)
-	- [1.7 List of Stored Procedures](#17-list-of-stored-procedures)
-	- [1.8 List of Triggers](#18-list-of-triggers)
+	- [1.2 Terms and abbreviations](#12-terms-and-abbreviations)
+	- [1.3 References](#13-references)
+	- [1.4 Database Version](#14-database-version)
+	- [1.5 Creating, Backing Up and Restoring the Database](#15-creating-backing-up-and-restoring-the-database)
+	- [1.6 Saving Database History](#16-saving-database-history)
+	- [1.7 High Availability Support](#17-high-availability-support)
+	- [1.8 Entity-Relationship Diagram](#18-entity-relationship-diagram)
+	- [1.9 List of Stored Procedures](#19-list-of-stored-procedures)
+	- [1.10 List of Triggers](#110-list-of-triggers)
 - [2 Description of Entities](#2-description-of-entities)
 	- [2.1 ANCHOR_URL_CERTS](#21-anchorurlcerts)
 		- [2.1.1 Indexes](#211-indexes)
@@ -115,17 +118,25 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 This document describes the database model of the X-Road central server.
 
-## 1.2 Database Version
+## 1.2 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+### 1.3 References
+
+1. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+
+## 1.4 Database Version
 
 This database assumes PostgreSQL version 9.3 or 9.4 depending on whether the central server is deployed in a simple setup or in a cluster for achieving high availability (HA) (see section 1.5 for details). Ubuntu 14.04 default settings are used in simple setup, while a custom configuration is used in HA setup.
 
-## 1.3 Creating, Backing Up and Restoring the Database
+## 1.5 Creating, Backing Up and Restoring the Database
 
 This database is integrated into X-Road central server application. The database management functions are embedded into the application user interface.
 The database, the database user and the data model is created by the application's installer. The database updates are packaged as application updates and are applied when the application is upgraded. From the technical point of view, the database structure is created and updated using Rails migrations (see http://guides.rubyonrails.org/). The migration scripts can be found both in application source and in WAR file of central server's web based user interface (WAR – Java Web Archive).
 Database backup functionality is built into the application. The backup operation can be invoked from the web-based user interface or from the command line. The backup contains dump of all the database structure and contents. When restoring the application, first the software is installed and then the configuration database is restored together with all the other necessary files. This produces a working central server.
 
-## 1.4 Saving Database History
+## 1.6 Saving Database History
 
 This section describes the general mechanism for storing the history of the database tables. All the history-aware tables have an associated trigger update_history that records all the modifications to data. All the tables of central database are history-aware, except for
 
@@ -135,7 +146,7 @@ This section describes the general mechanism for storing the history of the data
 
 When a row is created, updated or deleted in one of the history-aware tables, the trigger update_history is activated and invokes the stored procedure add_history_rows. For each changed column, add_history_rows inserts a row into the history table. The details of the stored procedures are described in section 1.7.
 
-## 1.5 High Availability Support
+## 1.7 High Availability Support
 
 High availability of the X-Road central server has been implemented using the BDR extension of the PostgreSQL database (http://2ndquadrant.com/en/resources/bdr/). The implementation is an asynchronous multi-master setup where the database changes to any node of the cluster are replicated to the rest of the nodes. Each node runs a separate instance of the UI of the central server and uses separate keys for signing configuration.
 
@@ -145,7 +156,7 @@ The logic of taking into account the value of ha_node_name where applicable, has
 
 Database history records are aware of the node name in an HA setup and are replicated just like other records. Thus each node contains the full history of database changes. Because replication events happen at a lower level than insertions of records, the replication of history records themselves does not trigger any subsequent insertions of history records on target nodes.
 
-## 1.6 Entity-Relationship Diagram
+## 1.8 Entity-Relationship Diagram
 
 The data model is described in two entity relationship diagrams (ERD). The first diagram contains tables related to security servers and security server clients. The second diagram contains the rest of the tables.
 
@@ -153,7 +164,7 @@ The data model is described in two entity relationship diagrams (ERD). The first
 
 Figure 1. ERD describing the database tables in the central server database
 
-## 1.7 List of Stored Procedures
+## 1.9 List of Stored Procedures
 
 The following stored procedures are present in the database, regardless of whether a given central server has been installed in standalone or HA setup.
 
@@ -163,7 +174,7 @@ The following stored procedures are present in the database, regardless of wheth
 - the default value in standalone systems
 - the name of the cluster node that initiated the insertion, in an HA setup.
 
-## 1.8 List of Triggers
+## 1.10 List of Triggers
 
 The following triggers are present in the database, regardless of whether a given central server has been installed in standalone or HA setup.
 

--- a/doc/DataModels/dm-ml_x-road_message_log_data_model.md
+++ b/doc/DataModels/dm-ml_x-road_message_log_data_model.md
@@ -1,6 +1,6 @@
 # X-Road: Message Log Data Model
 
-Version: 1.3  
+Version: 1.5  
 Doc. ID: DM-ML
 
 | Date       | Version     | Description                                     | Author             |
@@ -17,15 +17,18 @@ Doc. ID: DM-ML
 | 16.12.2016 | 1.2         | Described index added to message log            | Martin Lind        |
 | 16.02.2017 | 1.3         | Converted to markdown                           | Ilkka Seppälä      |
 | 16.02.2017 | 1.4         | Added index to logrecord, fixed earlier logrecord index name  | Olli Lindgren      |
+| 02.03.2018 | 1.5         | Added uniform terms and conditions reference    | Tatu Repo |
 
 ##Table of Contents
 
-- [General](#1-general)
-  - [Preamble](#11-preamble)
-  - [Database Version](#12-database-version)
-  - [Creating, Backing Up and Restoring the Database](#13-creating-backing-up-and-restoring-the-database)
-  - [Message Logging and Timestamping](#14-message-logging-and-timestamping)
-  - [Entity-Relationship Diagram](#15-entity-relationship-diagram)
+- [1 General](#1-general)
+  - [1.1 Preamble](#11-preamble)
+  - [1.2 Terms and abbreviations](#12-terms-and-abbreviations)
+  - [1.3 References](#13-references)
+  - [1.4 Database Version](#14-database-version)
+  - [1.5 Creating, Backing Up and Restoring the Database](#15-creating-backing-up-and-restoring-the-database)
+  - [1.6 Message Logging and Timestamping](#16-message-logging-and-timestamping)
+  - [1.7 Entity-Relationship Diagram](#17-entity-relationship-diagram)
 - [Description of Entities](#2-description-of-entities)
   - [LOGRECORD](#21-logrecord)
     - [Indexes](#211-indexes)
@@ -43,11 +46,19 @@ Doc. ID: DM-ML
 
 This document describes database model of X-Road message log.
 
-## 1.2 Database Version
+## 1.2 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+### 1.3 References
+
+1. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+
+## 1.4 Database Version
 
 This database assumes PostgreSQL version 9.3. Ubuntu 14.04 default settings are used.
 
-## 1.3 Creating, Backing Up and Restoring the Database
+## 1.5 Creating, Backing Up and Restoring the Database
 
 This database is integrated into X-Road message log component.
 
@@ -55,7 +66,7 @@ The database, the database user and the data model is created by the component's
 
 The database is used for logging purposes only and does not contain any configuration. Backing-up and restoring the database is not necessary for the functioning of the component.
 
-## 1.4 Message Logging and Timestamping
+## 1.6 Message Logging and Timestamping
 
 The input to the message log component consists of a message and its corresponding signature (along with hash chain and hash chain result if the signature is a batch signature). Depending on the security policy, timestamping can be asynchronous (one or more signatures are batch timestamped) or synchronous (to guarantee the timestamp).
 
@@ -70,7 +81,7 @@ When timestamping synchronously, the logging call will block until the timestamp
 1. The system saves the message and signature in the message log.
 2. System timestamps the message synchronously.
 
-## 1.5 Entity-Relationship Diagram
+## 1.7 Entity-Relationship Diagram
 
 ![Entity-Relationship Diagram](img/messagelog-er-diagram.png)
 

--- a/doc/EnvironmentalMonitoring/Monitoring-architecture.md
+++ b/doc/EnvironmentalMonitoring/Monitoring-architecture.md
@@ -1,6 +1,6 @@
 # X-Road: Environmental Monitoring Architecture
 
-Version: 1.3  
+Version: 1.6  
 Doc. ID: ARC-ENVMON
 
 | Date       | Version     | Description                                                                  | Author             |
@@ -11,23 +11,26 @@ Doc. ID: ARC-ENVMON
 | 23.2.2017 | 1.3       | Added reference to the Security Server targeting extension and moved the modified X-Road protocol details there | Olli Lindgren |
 | 18.8.2017 | 1.4       | Added details about the security server certificates monitoring data | Olli Lindgren |
 | 18.10.2017| 1.5       |  | Joni Laurila |
+| 02.03.2018| 1.6       | Added numbering, terms document references, removed unnecessary anchors | Tatu Repo
 
-## Table of Contents
+# Table of Contents
 <!-- toc -->
 
   * [License](#license)
-  * [Overview](#overview)
-  * [References](#references)
-- [Components](#components)
-  * [Monitoring metaservice (proxymonitor add-on)](#monitoring-metaservice-proxymonitor-add-on)
-  * [Monitoring service (xroad-monitor)](#monitoring-service-xroad-monitor)
-  * [Central monitoring client](#central-monitoring-client)
-  * [Central monitoring data collector](#central-monitoring-data-collector)
-  * [Central server admin user interface](#central-server-admin-user-interface)
-- [Monitoring in action](#monitoring-in-action)
-  * [Pull messaging model](#pull-messaging-model)
-  * [Modified X-Road message protocol](#modified-x-road-message-protocol)
-  * [Access control](#access-control)
+- [1 Overview](#1-overview)
+  * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+  * [1.2 References](#12-references)
+- [2 Components](#2-components)
+  * [2.1 Monitoring metaservice (proxymonitor add-on)](#21-monitoring-metaservice-proxymonitor-add-on)
+  * [2.2 Monitoring service (xroad-monitor)](#22-monitoring-service-xroad-monitor)
+  * [2.3 Central monitoring client](#23-central-monitoring-client)
+  * [2.4 Central monitoring data collector](#24-central-monitoring-data-collector)
+  * [2.5 Central server admin user interface](#25-central-server-admin-user-interface)
+- [3 Monitoring in action](#26-monitoring-in-action)
+  * [3.1 Pull messaging model](#27-pull-messaging-model)
+  * [3.2 Modified X-Road message protocol](#28-modified-x-road-message-protocol)
+  * [3.3 Access control](#29-access-control)
+    * [3.3.1 Limiting central monitoring client access for environmental monitor data](#331-limiting-central-monitoring-client-access-for-environmental-monitor-data)
 
 <!-- tocstop -->
 
@@ -36,7 +39,7 @@ Doc. ID: ARC-ENVMON
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
 
-## Overview
+## 1 Overview
 
 X-Road monitoring is conceptually split into two parts: _environmental_ and _operational_ monitoring:
 
@@ -45,29 +48,33 @@ X-Road monitoring is conceptually split into two parts: _environmental_ and _ope
 
 This document describes environmental monitoring architecture.
 
-<a name="refsanchor"></a>
-## References
+### 1.1 Terms and abbreviations
 
-| Code||
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+### 1.2 References
+
+| Document ID||
 | ------------- |-------------|
-| PR-GCONF      | Cybernetica AS. X-Road: Protocol for Downloading Configuration |
-| UC-GCONF      | Cybernetica AS. X-Road: Use Case Model for Global Configuration Distribution|
-| PR-MESS | Cybernetica AS.X-Road: Message Protocol v4.0      |
-| PR-TARGETSS | Security Server targeting extension for the X-Road message protocol |
+| PR-GCONF      | [Cybernetica AS. X-Road: Protocol for Downloading Configuration](../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md) |
+| UC-GCONF      | [Cybernetica AS. X-Road: Use Case Model for Global Configuration Distribution](../UseCases/uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md)|
+| PR-MESS | [Cybernetica AS.X-Road: Message Protocol v4.0](../Protocols/pr-mess_x-road_message_protocol.md)      |
+| PR-TARGETSS | [Security Server targeting extension for the X-Road message protocol](../Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md) |
+| <a id="Ref_TERMS" class="anchor"></a> TA-TERMS | [X-Road Terms and Abbreviations](../terms_x-road_docs.md)| 
 
-# Components
+## 2 Components
 
 ![monitoring architecture](img/monitoring.png)
 
-## Monitoring metaservice (proxymonitor add-on)
+### 2.1 Monitoring metaservice (proxymonitor add-on)
 
 Monitoring metaservice responds to queries for monitoring data from security server's serverproxy interface. This metaservice requests the current monitoring data from local monitoring service, using [Akka](http://akka.io/). Monitoring metaservice translates the monitoring data to a SOAP XML response.
 
-Monitoring service handles authorization of the requests, see [Access control](#acanchor). It reads monitoring configuration from distributed global monitoring configuration (see [UC-GCONF, PR-GCONF](#refsanchor)).
+Monitoring service handles authorization of the requests, see [Access control](#33-access-control). It reads monitoring configuration from distributed global monitoring configuration (see [UC-GCONF, PR-GCONF](#12-references)).
 
 Monitoring metaservice is installed as a proxy add-on, with name `xroad-addon-proxymonitor`.
 
-## Monitoring service (xroad-monitor)
+### 2.2 Monitoring service (xroad-monitor)
 
 Monitoring service is responsible for collecting the monitoring data from one security server instance. It distributes the collected data to monitoring clients (normally the local monitoring metaservice) when requested through an Akka interface.
 
@@ -121,20 +128,19 @@ The service also publishes the monitoring data via JMX. Local monitoring agents 
 
 ![monitoring JMX agent](img/monitoring-jmx.png)
 
-## Central monitoring client
+### 2.3 Central monitoring client
 
-Central monitoring client is a specific security server, which has been granted access to query monitoring data from other security servers. See [Access control](#acanchor). The identity of this security server is configured using central server's admin user interface.
+Central monitoring client is a specific security server, which has been granted access to query monitoring data from other security servers. See [Access control](#33-access-control). The identity of this security server is configured using central server's admin user interface.
 
-## Central monitoring data collector
+### 2.4 Central monitoring data collector
 
 Central monitoring data collector is responsible for collecting monitoring data from all the security servers. It does this by executing monitoring requests through the central monitoring client to all known security server instances. Data collector stores the data in some permanent storage, where it can be analyzed.
 
 Data collector has not been implemented yet.
 
-<a name="adminanchor"></a>
-## Central server admin user interface
+### 2.5 Central server admin user interface
 
-Identity of central monitoring client (if any) is configured using central server's admin user interface. Configuration is done by updating a specific optional configuration file (see [UC-GCONF](#refsanchor), "UC GCONF_05: Upload an Optional Configuration Part File") `monitoring-params.xml`. This configuration file is distributed to all security servers through the global configuration distribution process (see [UC-GCONF](#refsanchor), "UC GCONF_24: Download Configuration from a Configuration Source")
+Identity of central monitoring client (if any) is configured using central server's admin user interface. Configuration is done by updating a specific optional configuration file (see [UC-GCONF](#12-references), "UC GCONF_05: Upload an Optional Configuration Part File") `monitoring-params.xml`. This configuration file is distributed to all security servers through the global configuration distribution process (see [UC-GCONF](#12-references), "UC GCONF_24: Download Configuration from a Configuration Source")
 
 ```xml
 <tns:conf xmlns:id="http://x-road.eu/xsd/identifiers"
@@ -167,9 +173,9 @@ To disable central monitoring client altogether, update configuration to one whi
 </tns:conf>
 ```
 
-# Monitoring in action
+## 3 Monitoring in action
 
-## Pull messaging model
+### 3.1 Pull messaging model
 
 Currently central monitoring data collection is done using _pull_ messaging model. Here, pull means that the central monitoring client sends requests to the individual security servers.
 
@@ -177,9 +183,9 @@ An alternative to this would be model where security servers periodically _push_
 
 To support clustered configurations, monitoring queries use an extended X-Road message protocol.
 
-## Using an extension of the X-Road message protocol
+### 3.2 Using an extension of the X-Road message protocol
 
-Fetching security server metrics uses the X-Road protocol. The original X-Road message protocol version 4.0  (described in [PR-MESS](#refsanchor)) had header element `service` to define the recipient of a message.
+Fetching security server metrics uses the X-Road protocol. The original X-Road message protocol version 4.0  (described in [PR-MESS](#12-references)) had header element `service` to define the recipient of a message.
 
 ```xml
 <SOAP-ENV:Envelope
@@ -210,7 +216,7 @@ xmlns:prod="http://vrk-test.x-road.fi/producer">
 </SOAP-ENV:Envelope>
 ```
 
-For monitoring queries this is not enough. In a clustered security server configuration, one service can be served from multiple security servers. When X-Road routes the message, it picks one candidate based on which one answers the quickest. When executing monitoring queries, we need to be able to fetch monitoring data from a specific security server in a cluster. To make this possible the Security server targeting extension for the X-Road message protocol \[[PR-TARGETSS](#refsanchor)\] is used, which adds a new SOAP header element `securityServer`. Using this element, the caller identifies which security server should respond with the monitoring data (`servercode` = `fdev-ss1.i.palveluvayla.com`). To execute a query, we call service `getSecurityServerMetrics`:
+For monitoring queries this is not enough. In a clustered security server configuration, one service can be served from multiple security servers. When X-Road routes the message, it picks one candidate based on which one answers the quickest. When executing monitoring queries, we need to be able to fetch monitoring data from a specific security server in a cluster. To make this possible the Security server targeting extension for the X-Road message protocol \[[PR-TARGETSS](#12-references)\] is used, which adds a new SOAP header element `securityServer`. Using this element, the caller identifies which security server should respond with the monitoring data (`servercode` = `fdev-ss1.i.palveluvayla.com`). To execute a query, we call service `getSecurityServerMetrics`:
 
 ```xml
 <SOAP-ENV:Envelope
@@ -374,20 +380,19 @@ The schema for the monitoring response is defined in `monitoring.xsd`:
 </schema>
 ```
 
-## Access control
-<a name="acanchor"></a>
+### 3.3 Access control
 
 Monitoring queries are allowed from
 - client that is the _owner_ of the security server
 - central monitoring client (if any have been configured)
 
-Central monitoring client is configured using central server admin user interface, see [Admin user interface](#adminanchor).
+Central monitoring client is configured using central server admin user interface, see [Admin user interface](#25-central-server-admin-user-interface).
 
 Attempts to query monitoring data from other clients results in an `AccessDenied` -error.
 
 JMX API, in case port and network access is enabled, will provide monitoring data directly without access control checks by security server. 
 
-### Limiting central monitoring client access for environmental monitor data
+#### 3.3.1 Limiting central monitoring client access for environmental monitor data
 
 Request for monitor data can be set for limiting optional parts by changing env-monitor.limit-remote-data-set parameter. By limiting data set environmental monitoring will return only proxyVersion, OperatingSystem and Certificate information. 
 

--- a/doc/EnvironmentalMonitoring/Monitoring-architecture.md
+++ b/doc/EnvironmentalMonitoring/Monitoring-architecture.md
@@ -26,10 +26,10 @@ Doc. ID: ARC-ENVMON
   * [2.3 Central monitoring client](#23-central-monitoring-client)
   * [2.4 Central monitoring data collector](#24-central-monitoring-data-collector)
   * [2.5 Central server admin user interface](#25-central-server-admin-user-interface)
-- [3 Monitoring in action](#26-monitoring-in-action)
-  * [3.1 Pull messaging model](#27-pull-messaging-model)
-  * [3.2 Modified X-Road message protocol](#28-modified-x-road-message-protocol)
-  * [3.3 Access control](#29-access-control)
+- [3 Monitoring in action](#3-monitoring-in-action)
+  * [3.1 Pull messaging model](#31-pull-messaging-model)
+  * [3.2 Modified X-Road message protocol](#32-modified-x-road-message-protocol)
+  * [3.3 Access control](#33-access-control)
     * [3.3.1 Limiting central monitoring client access for environmental monitor data](#331-limiting-central-monitoring-client-access-for-environmental-monitor-data)
 
 <!-- tocstop -->

--- a/doc/EnvironmentalMonitoring/Monitoring-messages.md
+++ b/doc/EnvironmentalMonitoring/Monitoring-messages.md
@@ -37,7 +37,7 @@ This document describes the request and response messages for environmental moni
 
 ### 1.1 Terms and abbreviations
 
-See X-Road terms and abbreviations documentation [TA-TERMS](#Ref_TERMS).
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 

--- a/doc/EnvironmentalMonitoring/Monitoring-messages.md
+++ b/doc/EnvironmentalMonitoring/Monitoring-messages.md
@@ -1,6 +1,6 @@
 # X-Road: Environmental Monitoring Messages
 
-Version: 1.3  
+Version: 1.5  
 Doc. ID: PR-ENVMONMES
 
 | Date       | Version     | Description                                                | Author          |
@@ -10,17 +10,20 @@ Doc. ID: PR-ENVMONMES
 | 20.01.2017 | 1.2         | Added license text, table of contents and version history  | Sami Kallio     |
 | 23.02.2017 | 1.3         | Added reference to security server targeting extension     | Olli Lindgren   |
 | 24.08.2017 | 1.4         | Added outputSpec parameter to getSecurityServerMetrics     | Tomi Tolvanen   |
+| 06.03.2018 | 1.5         | Added terms and abbreviations references, numbering and Introduction chapter structure | Tatu Repo |
 
 ## Table of Contents
 
 <!-- toc -->
 
 - [License](#license)
-- [Fetching security server metrics](#fetching-security-server-metrics)
-  * [Request](#request)
-  * [Response](#response)
-  * [Response Schema](#response-schema)
-- [References](#references)
+- [1 Introduction](#1-introduction)
+  * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+  * [1.2 References](#12-references)
+- [2 Fetching security server metrics](#2-fetching-security-server-metrics)
+  * [2.1 Request](#21-request)
+  * [2.2 Response](#22-response)
+  * [2.3 Response Schema](#23-response-schema)
 
 <!-- tocstop -->
 
@@ -28,9 +31,25 @@ Doc. ID: PR-ENVMONMES
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
-## Fetching security server metrics
+## 1 Introduction
 
-### Request
+This document describes the request and response messages for environmental monitoring. 
+
+### 1.1 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation [TA-TERMS](#Ref_TERMS).
+
+### 1.2 References
+
+| Document ID||
+| ------------- |-------------|
+| <a name="Ref_PR-TARGETSS"></a>\[PR-TARGETSS\] | [Security server targeting extension for the X-Road message protocol](../Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md)  |
+| <a name="Ref_TERMS"></a>\[TA-TERMS\] | [X-Road Terms and Abbreviations](../terms_x-road_docs.md)
+
+
+## 2 Fetching security server metrics
+
+### 2.1 Request
 
 Fetching security server metrics uses the X-Road protocol. The `getSecurityServerMetrics` request requires a `securityServer` header element as specified by the security server targeting extension for the X-Road message protocol \[[PR-TARGETSS](#Ref_PR-TARGETSS)\] so that the request can be routed to a specific security server.
 
@@ -82,7 +101,7 @@ An optional `outputSpec` child element can be used to request a subset of the me
 </SOAP-ENV:Envelope>
 ```
 
-### Response
+### 2.2 Response
 
 The response `Body` contains one `getSecurityServerMetricsResponse` element which contains one `metricSet` as direct child. The name of the top level set is the security server identifier. The set contains a _proxyVersion_ `stringMetric` and a _systemMetrics_ `metricSet`. The _systemMetrics_ set contains the requested metrics.
 
@@ -140,7 +159,7 @@ The response `Body` contains one `getSecurityServerMetricsResponse` element whic
 </SOAP-ENV:Envelope>
 ```
 
-### Response Schema
+### 2.3 Response Schema
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -212,8 +231,3 @@ The response `Body` contains one `getSecurityServerMetricsResponse` element whic
     <xs:element name="getSecurityServerMetrics" type="tns:getSecurityServerMetricsType"/>
 </schema>
 ```
-## References
-
-| Code||
-| ------------- |-------------|
-| <a name="Ref_PR-TARGETSS"></a>\[PR-TARGETSS\] | Security server targeting extension for the X-Road message protocol  |

--- a/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md
+++ b/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md
@@ -1,6 +1,6 @@
 # X-Road: External Load Balancer Installation Guide
 
-Version: 1.3  
+Version: 1.4  
 Doc. ID: IG-XLB
 
 
@@ -10,6 +10,7 @@ Doc. ID: IG-XLB
 | 27.4.2017   | 1.1         | Added slave node user group instructions                                                                                 | Tatu Repo                    |
 | 15.6.2017   | 1.2         | Added health check interface maintenance mode                                                                            | Tatu Repo                    |
 | 21.6.2017   | 1.3         | Added chapter 7 on [upgrading the security server cluster](#7-upgrading-a-clustered-x-road-security-server-installation) | Olli Lindgren                |
+| 02.03.2018  | 1.4         | Added uniform terms and conditions reference                                                                             | Tatu Repo                    |
 
 ## Table of Contents
 
@@ -18,7 +19,8 @@ Doc. ID: IG-XLB
 - [License](#license)
 - [1. Introduction](#1-introduction)
   * [1.1 Target Audience](#11-target-audience)
-  * [1.2 References](#12-references)
+  * [1.2 Terms and abbreviations](#12-terms-and-abbreviations)
+  * [1.3 References](#13-references)
 - [2. Overview](#2-overview)
   * [2.1 Goals and assumptions](#21-goals-and-assumptions)
   * [2.2 Communication with external servers and services: The cluster from the point of view of a client or service](#22-communication-with-external-servers-and-services-the-cluster-from-the-point-of-view-of-a-client-or-service)
@@ -77,14 +79,18 @@ and configuring X-Road security servers to use external load balancing. The docu
 knowledge of Linux server management, computer networks, database administration, clustered environments and the X-Road
 functioning principles.
 
-### 1.2 References
+### 1.2 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+### 1.3 References
 
 | Document Id    |  Document                                                                                |
 |:--------------:|:-----------------------------------------------------------------------------------------|
 | \[SS-CLUSTER\] | [Readme: Security server cluster setup with Ansible](../../../ansible/ss_cluster/README.md) |
 | \[IG-SS\] | [X-Road: Security Server Installation Guide](../ig-ss_x-road_v6_security_server_installation_guide.md) |
 | \[UG-SS\] | [X-Road 6 Security Server User Guide](../ug-ss_x-road_6_security_server_user_guide.md) |
-
+| <a name="Ref_TERMS"></a>\[TA-TERMS\] | [X-Road Terms and Abbreviations](../../terms_x-road_docs.md)
 
 ## 2. Overview
 
@@ -216,7 +222,7 @@ replication cannot simultaneously create a single point of failure. A distribute
 
 This chapter details the complete installation on a high level, with links to other chapters that go into the details.
 
-You can set up the cluster manually, or use the provided Ansible playbook \[[SS-CLUSTER](#12-references)\] if it suits
+You can set up the cluster manually, or use the provided Ansible playbook \[[SS-CLUSTER](#13-references)\] if it suits
 your purposes.
 
 ### 3.1 Prerequisites
@@ -236,7 +242,7 @@ In order to properly set up the data replication, the slave nodes must be able t
    * `serverconf.hibernate.connection.url` : Change the url port number from `5432` to `5433` (or the port you specified)
 5. If you are using an already configured server as the master, the existing configuration was replicated to the slaves
    in step 3. Otherwise, proceed to configure the master server: install the configuration anchor, set up basic information,
-   create authentication and signing keys and so on. See the security server installation guide \[[IG-SS](#12-references)\]
+   create authentication and signing keys and so on. See the security server installation guide \[[IG-SS](#13-references)\]
    for help with the basic setup.
 6. Set up the configuration file replication, see section
    [5. Configuring data replication with rsync over SSH](#5-configuring-data-replication-with-rsync-over-ssh)
@@ -296,7 +302,7 @@ In order to properly set up the data replication, the slave nodes must be able t
 
    After removing these groups, the super user created during the security server installation is a member of only one UI privilege group: `xroad-securityserver-observer`. This group allows read-only access to the admin user interface and provides a safe way to use the UI for checking the configuration status of the slave security server. Since admin UI users are UNIX users that are members of specific privilege groups, more users can be added to the read-only group as necessary. Security server installation scripts detect the node type of existing installations and modify user group creation accordingly so as to not overwrite this configuration step during security server updates.
 
-   For more information on user groups and their effect on admin user interface privileges in the security server, see the  Security Server User Guide \[[UG-SS](#12-references)\].
+   For more information on user groups and their effect on admin user interface privileges in the security server, see the  Security Server User Guide \[[UG-SS](#13-references)\].
 10. It is possible to use the autologin-package with slave nodes to enable automatic PIN-code insertion, however the autologin-package default implementation stores PIN-codes in plain text and should not be used in production environments. Instructions on how to configure the autologin-package to use a more secure custom PIN-code storing implementation can be found in [autologin documentation](../Utils/ug-autologin_x-road_v6_autologin_user_guide.md)
 
 The configuration is now complete. If you do not want to set up the health check service, continue to [chapter 6](#6-verifying-the-setup)

--- a/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md
+++ b/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md
@@ -871,7 +871,7 @@ server cluster behind a load balancer.
 To test the configuration file replication from the admin user interface, a key can be created in the admin interface of the
 master node. In addition, a certificate signing request can be created for the key in the UI, downloaded, signed by an
 external CA and then uploaded back to the admin UI. For help on these tasks, see the  Security Server User Guide
-\[[UG-SS](#12-references)\].
+\[[UG-SS](#13-references)\].
 
 The keys and certificate changes should be propagated to the slave nodes in a few minutes.
 
@@ -889,7 +889,7 @@ disrupt message delivery while the online option should allow upgrades with mini
 If the X-Road security server cluster can be shut down for an offline upgrade, the procedure remains fairly simple:
 1. Stop the X-Road services (`xroad-proxy`, `xroad-signer`, `xroad-confclient`, `xroad-jetty` and `xroad-monitor`) on all
    the nodes. You can read more about the services in the Security Server User Guide
-\[[UG-SS](#12-references)\] chapter on [System services](../ug-ss_x-road_6_security_server_user_guide.md#161-system-services).
+\[[UG-SS](#13-references)\] chapter on [System services](../ug-ss_x-road_6_security_server_user_guide.md#161-system-services).
 2. Upgrade the packages on the master node to the new software version.
 3. Let any database and configuration changes propagate to the cluster members.
 4. Upgrade the packages on the slave nodes.
@@ -945,7 +945,7 @@ The steps are in more detail below, but in short, the procedure is:
 2. <a name="master-upgrade-step-2">Check</a> that the master is no longer processing requests and stop the X-Road services
    (`xroad-proxy`, `xroad-signer`, `xroad-confclient`, `xroad-jetty`, `xroad-monitor`) on the master node. You can read
    more about the services in the Security Server User Guide
-   \[[UG-SS](#12-references)\] chapter on [System services](../ug-ss_x-road_6_security_server_user_guide.md#161-system-services).
+   \[[UG-SS](#13-references)\] chapter on [System services](../ug-ss_x-road_6_security_server_user_guide.md#161-system-services).
 
    To ensure that the node is no longer processing requests, you can monitor `/var/log/xroad/proxy.log` to verify that
    no more requests are arriving or check that there are no connections to the port 5500 with:

--- a/doc/Manuals/Utils/ug-autologin_x-road_v6_autologin_user_guide.md
+++ b/doc/Manuals/Utils/ug-autologin_x-road_v6_autologin_user_guide.md
@@ -7,7 +7,20 @@ Doc. ID: UG-AUTOLOGIN
 | Date        | Version     | Description                                                                                             
 |-------------|-------------|---------------------------------------------------------------------------------------------------------
 | 23.08.2017  | 1.0         | Initial version             
-| 06.03.2018  | 1.1         | Added chapter and section structure, terms and refs sections and term doc reference and link                   
+| 06.03.2018  | 1.1         | Added chapter and section structure, terms and refs sections and term doc reference and link, toc                   
+
+## Table of Contents
+
+<!-- toc -->
+
+- [1 Introduction](#1-introduction)
+    + [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+    + [1.2 References](#12-references)
+- [2 Overview](#2-overview)
+    + [2.1 Usage](#21-usage)
+    + [2.2 Implementation details](#22-implementation-details)
+    
+<!-- tocstop -->
 
 ## 1 Introduction
 

--- a/doc/Manuals/Utils/ug-autologin_x-road_v6_autologin_user_guide.md
+++ b/doc/Manuals/Utils/ug-autologin_x-road_v6_autologin_user_guide.md
@@ -1,18 +1,28 @@
 # X-Road: Autologin User Guide
 
-Version: 1.0  
+Version: 1.1  
 Doc. ID: UG-AUTOLOGIN
 
 
 | Date        | Version     | Description                                                                                             
 |-------------|-------------|---------------------------------------------------------------------------------------------------------
-| 23.8.2017   | 1.0         | Initial version             
+| 23.08.2017  | 1.0         | Initial version             
+| 06.03.2018  | 1.1         | Added chapter and section structure, terms and refs sections and term doc reference and link                   
 
-# Autologin
+## 1 Introduction
 
-An utility which automatically enters the PIN code after `xroad-signer` has started.
+This document describes the Autologin utility which automatically enters the PIN code after `xroad-signer` has started.
 
-## Usage
+### 1.1 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+### 1.2 References
+
+1. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
+
+## 2 Overview
+### 2.1 Usage
 
 1. Install the package
   * Ubuntu: apt install xroad-autologin
@@ -36,7 +46,7 @@ An utility which automatically enters the PIN code after `xroad-signer` has star
   exit 0
   ```
 
-## Implementation details
+### 2.2 Implementation details
 
 * Creates a new service `xroad-autologin`
 * Service is started after `xroad-signer` has started

--- a/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
+++ b/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server Installation Guide
 
-Version: 2.5  
+Version: 2.6  
 Doc. ID: IG-CS
 
 
@@ -21,6 +21,7 @@ Doc. ID: IG-CS
 | 20.12.2016 | 2.3     | Add chapter about additional configuration to central server's user manual          | Ilkka Seppälä |
 | 20.01.2017 | 2.4       | Added license text and version history | Sami Kallio |
 | 25.08.2017 | 2.5       | Update installation instructions concerning the support for environmental monitoring  | Ilkka Seppälä |
+| 05.03.2018 | 2.6     | Added terms and abbreviations reference, links to references and actual documents | Tatu Repo | 
 
 ## Table of Contents
 
@@ -29,7 +30,8 @@ Doc. ID: IG-CS
   * [License](#license)
 - [1. Introduction](#1-introduction)
   * [1.1 Target Audience](#11-target-audience)
-  * [1.2 References](#12-references)
+  * [1.2 Terms and abbreviations](#12-terms-and-abbreviations)
+  * [1.3 References](#13-references)
 - [2. Installation](#2-installation)
   * [2.1 Prerequisites to Installation](#21-prerequisites-to-installation)
   * [2.2 Reference Data](#22-reference-data)
@@ -64,12 +66,17 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 The intended audience of this installation guide are the X-Road central server administrators responsible for installing and configuring the X-Road central server software.
 The document is intended for readers with a good knowledge of Linux server management, computer networks, and the X-Road functioning principles.
 
-## 1.2 References
+## 1.2 Terms and abbreviations
 
-1. [UG-CS] Cybernetica AS. X-Road 6. Central Server User Guide
-2. [IG-SS] Cybernetica AS. X-Road 6. Security Server Installation Guide
-3. [UG-SS] Cybernetica AS. X-Road 6. Security Server User Guide
-4. [IG-CSHA] Cybernetica AS. X-Road 6. Central Server High Availability Installation Guide
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+## 1.3 References
+
+1. [UG-CS] Cybernetica AS. X-Road 6. Central Server User Guide, [UG-CS](ug-cs_x-road_6_central_server_user_guide.md) 
+2. [IG-SS] Cybernetica AS. X-Road 6. Security Server Installation Guide, [IG-SS](ig-ss_x-road_v6_security_server_installation_guide.md)
+3. [UG-SS] Cybernetica AS. X-Road 6. Security Server User Guide, [UG-SS](ug-ss_x-road_6_security_server_user_guide.md)
+4. [IG-CSHA] Cybernetica AS. X-Road 6. Central Server High Availability Installation Guide [IG-CSHA](ig-csha_x-road_6_ha_installation_guide.md)
+5. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 # 2. Installation
 
@@ -78,7 +85,7 @@ The document is intended for readers with a good knowledge of Linux server manag
 The central server software assumes an existing installation of the Ubuntu 14.04 operating system, on an x86-64bit platform.
 To provide management services, a security server is installed alongside the central server.
 The central server’s software can be installed both on physical and virtualized hardware (of the latter, Xen and Oracle VirtualBox have been tested).
-Note: If the central server is a part of a cluster for achieving high availability, the database cluster must be installed and configured before the central server itself can be installed. Please refer to the Central Server High Availability Installation Guide [IG-CSHA] for details.
+Note: If the central server is a part of a cluster for achieving high availability, the database cluster must be installed and configured before the central server itself can be installed. Please refer to the Central Server High Availability Installation Guide [IG-CSHA](#13-references) for details.
 
 ## 2.2 Reference Data
 
@@ -115,7 +122,7 @@ Requirements for software and settings:
 
 ## 2.4 Preparing OS
 
-- Add a system user (reference data: 1.3) whom all roles in the user interface are granted to. Add the new user with the command: `sudo adduser username`. User roles are discussed in detail in the X-Road Security Server User Guide [UG-SS].
+- Add a system user (reference data: 1.3) whom all roles in the user interface are granted to. Add the new user with the command: `sudo adduser username`. User roles are discussed in detail in the X-Road Security Server User Guide [UG-SS](#13-references).
 - Set the operating system locale. Add the following line to the file /etc/environment. `LC_ALL=en_US.UTF-8`
 
 ## 2.5 Installation
@@ -164,7 +171,7 @@ To configure support for hardware security tokens (smartcard, USB token, Hardwar
 
 The optional configuration for environmental monitoring parameters is installed by package xroad-centralserver-monitoring. This package also includes the components that validate the updated xml monitoring configuration. The package is included in the central server installation by default.
 
-The central monitoring client may be configured as specified in the [UG-CS].
+The central monitoring client may be configured as specified in the [UG-CS](#13-references).
 
 # 3 Initial Configuration
 
@@ -195,21 +202,21 @@ Upon the first configuration of the central server and the management services' 
 
 Actions 7 and 8 must be performed in the management services' security server.
 
-1. Generate the internal and external configuration signing keys. Refer to [UG-CS] section „Generating a Configuration Signing Key“.
-2. Configure the member classes. Refer to [UG-CS] section „Managing the Member Classes“. (reference data: 2.4).
+1. Generate the internal and external configuration signing keys. Refer to [UG-CS](#13-references) section „Generating a Configuration Signing Key“.
+2. Configure the member classes. Refer to [UG-CS](#13-references) section „Managing the Member Classes“. (reference data: 2.4).
 3. Configure the management service provider:
-add the X-Road member who will be responsible for management services - [UG-CS] section „Adding a Member“;
-add the subsystem that will provide the management services to the X-Road member - [UG-CS] section “Adding a Subsystem to an X-Road Member”;
-appoint the subsystem as the management service provider - [UG-CS] section “Appointing the Management Service Provider”.
-4. Configure the certification services. Refer to [UG-CS] section „Managing the Approved Certification Services“.
-5. Configure the timestamping services. Refer to [UG-CS] section „Managing the Approved Timestamping Services“.
-6. Verify that the global configuration generation succeeds (no global error messages should be displayed in the user interface at this point) and download the internal configuration anchor - [UG-CS] section “Downloading the Configuration Anchor”. The anchor is needed to set up the management services' security server.
-7. Install and configure the management services' security server as described in [IG-SS].
-8. Register the management services' security server in the central server. Refer to [UG-SS] section „Security Server Registration“.
-9. Complete the registration of the management services' security server - [UG-CS] section “Registering a Member's Security Server”.
-10. Register the management service provider as a client of the management services' security server - [UG-CS] section “Registering the Management Service Provider as a Security Server Client”.
-11. Add the management service provider as a client to the management services' security server. Refer to [UG-SS] section „Adding a Security Server Client”. (The client should appear in “Registered” state, as the association between the client and the security server was already registered in the central server in the previous step). If necessary, configure the signing keys and certificates for the client - [UG-SS] section „Configuring a Signing Key and Certificate for a Security Server Client”
-12. Configure the management services. Refer to [UG-CS] section „Configuring the Management Services in The Management Services’ Security Server”.
+add the X-Road member who will be responsible for management services - [UG-CS](#13-references) section „Adding a Member“;
+add the subsystem that will provide the management services to the X-Road member - [UG-CS](#13-references) section “Adding a Subsystem to an X-Road Member”;
+appoint the subsystem as the management service provider - [UG-CS](#13-references) section “Appointing the Management Service Provider”.
+4. Configure the certification services. Refer to [UG-CS](#13-references) section „Managing the Approved Certification Services“.
+5. Configure the timestamping services. Refer to [UG-CS](#13-references) section „Managing the Approved Timestamping Services“.
+6. Verify that the global configuration generation succeeds (no global error messages should be displayed in the user interface at this point) and download the internal configuration anchor - [UG-CS](#13-references) section “Downloading the Configuration Anchor”. The anchor is needed to set up the management services' security server.
+7. Install and configure the management services' security server as described in [IG-SS](#13-references).
+8. Register the management services' security server in the central server. Refer to [UG-SS](#13-references) section „Security Server Registration“.
+9. Complete the registration of the management services' security server - [UG-CS](#13-references) section “Registering a Member's Security Server”.
+10. Register the management service provider as a client of the management services' security server - [UG-CS](#13-references) section “Registering the Management Service Provider as a Security Server Client”.
+11. Add the management service provider as a client to the management services' security server. Refer to [UG-SS](#13-references) section „Adding a Security Server Client”. (The client should appear in “Registered” state, as the association between the client and the security server was already registered in the central server in the previous step). If necessary, configure the signing keys and certificates for the client - [UG-SS](#13-references) section „Configuring a Signing Key and Certificate for a Security Server Client”
+12. Configure the management services. Refer to [UG-CS](#13-references) section „Configuring the Management Services in The Management Services’ Security Server”.
 
 # 4 Additional configuration
 

--- a/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
+++ b/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
@@ -72,10 +72,10 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ## 1.3 References
 
-1. [UG-CS] Cybernetica AS. X-Road 6. Central Server User Guide, [UG-CS](ug-cs_x-road_6_central_server_user_guide.md) 
-2. [IG-SS] Cybernetica AS. X-Road 6. Security Server Installation Guide, [IG-SS](ig-ss_x-road_v6_security_server_installation_guide.md)
-3. [UG-SS] Cybernetica AS. X-Road 6. Security Server User Guide, [UG-SS](ug-ss_x-road_6_security_server_user_guide.md)
-4. [IG-CSHA] Cybernetica AS. X-Road 6. Central Server High Availability Installation Guide [IG-CSHA](ig-csha_x-road_6_ha_installation_guide.md)
+1. <a id="Ref_UG-CS" class="anchor"></a>\[UG-CS\] Cybernetica AS. X-Road 6. Central Server User Guide. Document ID: [UG-CS](ug-cs_x-road_6_central_server_user_guide.md) 
+2. <a id="Ref_IG-SS" class="anchor"></a>\[IG-SS\] Cybernetica AS. X-Road 6. Security Server Installation Guide. Document ID: [IG-SS](ig-ss_x-road_v6_security_server_installation_guide.md)
+3. <a id="Ref_UG-SS" class="anchor"></a>\[UG-SS\] Cybernetica AS. X-Road 6. Security Server User Guide. Document ID: [UG-SS](ug-ss_x-road_6_security_server_user_guide.md)
+4. <a id="Ref_IG-CSHA" class="anchor"></a>\[IG-CSHA\] Cybernetica AS. X-Road 6. Central Server High Availability Installation Guide. Document ID: [IG-CSHA](ig-csha_x-road_6_ha_installation_guide.md)
 5. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 # 2. Installation
@@ -85,7 +85,7 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 The central server software assumes an existing installation of the Ubuntu 14.04 operating system, on an x86-64bit platform.
 To provide management services, a security server is installed alongside the central server.
 The central server’s software can be installed both on physical and virtualized hardware (of the latter, Xen and Oracle VirtualBox have been tested).
-Note: If the central server is a part of a cluster for achieving high availability, the database cluster must be installed and configured before the central server itself can be installed. Please refer to the Central Server High Availability Installation Guide [IG-CSHA](#13-references) for details.
+Note: If the central server is a part of a cluster for achieving high availability, the database cluster must be installed and configured before the central server itself can be installed. Please refer to the Central Server High Availability Installation Guide [IG-CSHA](#Ref_IG-CSHA) for details.
 
 ## 2.2 Reference Data
 
@@ -122,7 +122,7 @@ Requirements for software and settings:
 
 ## 2.4 Preparing OS
 
-- Add a system user (reference data: 1.3) whom all roles in the user interface are granted to. Add the new user with the command: `sudo adduser username`. User roles are discussed in detail in the X-Road Security Server User Guide [UG-SS](#13-references).
+- Add a system user (reference data: 1.3) whom all roles in the user interface are granted to. Add the new user with the command: `sudo adduser username`. User roles are discussed in detail in the X-Road Security Server User Guide [UG-SS](#Ref_UG-SS).
 - Set the operating system locale. Add the following line to the file /etc/environment. `LC_ALL=en_US.UTF-8`
 
 ## 2.5 Installation
@@ -171,7 +171,7 @@ To configure support for hardware security tokens (smartcard, USB token, Hardwar
 
 The optional configuration for environmental monitoring parameters is installed by package xroad-centralserver-monitoring. This package also includes the components that validate the updated xml monitoring configuration. The package is included in the central server installation by default.
 
-The central monitoring client may be configured as specified in the [UG-CS](#13-references).
+The central monitoring client may be configured as specified in the [UG-CS](#Ref_UG-CS).
 
 # 3 Initial Configuration
 
@@ -202,21 +202,21 @@ Upon the first configuration of the central server and the management services' 
 
 Actions 7 and 8 must be performed in the management services' security server.
 
-1. Generate the internal and external configuration signing keys. Refer to [UG-CS](#13-references) section „Generating a Configuration Signing Key“.
-2. Configure the member classes. Refer to [UG-CS](#13-references) section „Managing the Member Classes“. (reference data: 2.4).
+1. Generate the internal and external configuration signing keys. Refer to [UG-CS](#Ref_UG-CS) section „Generating a Configuration Signing Key“.
+2. Configure the member classes. Refer to [UG-CS](#Ref_UG-CS) section „Managing the Member Classes“. (reference data: 2.4).
 3. Configure the management service provider:
-add the X-Road member who will be responsible for management services - [UG-CS](#13-references) section „Adding a Member“;
-add the subsystem that will provide the management services to the X-Road member - [UG-CS](#13-references) section “Adding a Subsystem to an X-Road Member”;
-appoint the subsystem as the management service provider - [UG-CS](#13-references) section “Appointing the Management Service Provider”.
-4. Configure the certification services. Refer to [UG-CS](#13-references) section „Managing the Approved Certification Services“.
-5. Configure the timestamping services. Refer to [UG-CS](#13-references) section „Managing the Approved Timestamping Services“.
-6. Verify that the global configuration generation succeeds (no global error messages should be displayed in the user interface at this point) and download the internal configuration anchor - [UG-CS](#13-references) section “Downloading the Configuration Anchor”. The anchor is needed to set up the management services' security server.
-7. Install and configure the management services' security server as described in [IG-SS](#13-references).
-8. Register the management services' security server in the central server. Refer to [UG-SS](#13-references) section „Security Server Registration“.
-9. Complete the registration of the management services' security server - [UG-CS](#13-references) section “Registering a Member's Security Server”.
-10. Register the management service provider as a client of the management services' security server - [UG-CS](#13-references) section “Registering the Management Service Provider as a Security Server Client”.
-11. Add the management service provider as a client to the management services' security server. Refer to [UG-SS](#13-references) section „Adding a Security Server Client”. (The client should appear in “Registered” state, as the association between the client and the security server was already registered in the central server in the previous step). If necessary, configure the signing keys and certificates for the client - [UG-SS](#13-references) section „Configuring a Signing Key and Certificate for a Security Server Client”
-12. Configure the management services. Refer to [UG-CS](#13-references) section „Configuring the Management Services in The Management Services’ Security Server”.
+add the X-Road member who will be responsible for management services - [UG-CS](#Ref_UG-CS) section „Adding a Member“;
+add the subsystem that will provide the management services to the X-Road member - [UG-CS](#Ref_UG-CS) section “Adding a Subsystem to an X-Road Member”;
+appoint the subsystem as the management service provider - [UG-CS](#Ref_UG-CS) section “Appointing the Management Service Provider”.
+4. Configure the certification services. Refer to [UG-CS](#Ref_UG-CS) section „Managing the Approved Certification Services“.
+5. Configure the timestamping services. Refer to [UG-CS](#Ref_UG-CS) section „Managing the Approved Timestamping Services“.
+6. Verify that the global configuration generation succeeds (no global error messages should be displayed in the user interface at this point) and download the internal configuration anchor - [UG-CS](#Ref_UG-CS) section “Downloading the Configuration Anchor”. The anchor is needed to set up the management services' security server.
+7. Install and configure the management services' security server as described in [IG-SS](#Ref_IG-SS).
+8. Register the management services' security server in the central server. Refer to [UG-SS](#Ref_UG-SS) section „Security Server Registration“.
+9. Complete the registration of the management services' security server - [UG-CS](#Ref_UG-CS) section “Registering a Member's Security Server”.
+10. Register the management service provider as a client of the management services' security server - [UG-CS](#Ref_UG-CS) section “Registering the Management Service Provider as a Security Server Client”.
+11. Add the management service provider as a client to the management services' security server. Refer to [UG-SS](#Ref_UG-SS) section „Adding a Security Server Client”. (The client should appear in “Registered” state, as the association between the client and the security server was already registered in the central server in the previous step). If necessary, configure the signing keys and certificates for the client - [UG-SS](#Ref_UG-SS) section „Configuring a Signing Key and Certificate for a Security Server Client”
+12. Configure the management services. Refer to [UG-CS](#Ref_UG-CS) section „Configuring the Management Services in The Management Services’ Security Server”.
 
 # 4 Additional configuration
 

--- a/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
+++ b/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
@@ -6,8 +6,8 @@
 # Central Server High Availability Installation Guide
 **X-ROAD 6**
 
-Version: 1.4
-20.02.2017
+Version: 1.5  
+05.03.2018  
 Doc. ID: IG-CSHA
 
 ---
@@ -23,7 +23,7 @@ Doc. ID: IG-CSHA
  16.12.2015 | 1.2     | Added recovery information
  17.12.2015 | 1.3     | Editorial changes made
  20.02.2017 | 1.4     | Converted to Github flavoured Markdown, added license text, adjusted tables for better output in PDF | Toomas Mölder
-
+ 05.03.2018 | 1.5     | Added terms and abbreviations references and document links  | Tatu Repo
 
 ## Table of Contents
 
@@ -33,7 +33,8 @@ Doc. ID: IG-CSHA
 - [1 Introduction](#1-introduction)
   * [1.1 High Availability for X-Road Central Server](#11-high-availability-for-x-road-central-server)
   * [1.2 Target Audience](#12-target-audience)
-  * [1.3 References](#13-references)
+  * [1.3 Terms and abbreviations](#13-terms-and-conditions)
+  * [1.4 References](#14-references)
 - [2 Key Points and Known Limitations for X-Road Central Server HA Deployment](#2-key-points-and-known-limitations-for-x-road-central-server-ha-deployment)
 - [3 Requirements and Workflows for HA Configuration](#3-requirements-and-workflows-for-ha-configuration)
   * [3.1 Requirements](#31-requirements)
@@ -85,12 +86,17 @@ The intended audience of this installation guide are X-Road central server admin
 
 The document is intended for readers with a good knowledge of Linux server management, computer networks, and the X-Road functioning principles.
 
+### 1.3 Terms and abbreviations
 
-### 1.3 References
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\]
 
-1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] Cybernetica AS. X-Road 6. Central Server Installation Guide. Document ID: IG-CS.
+### 1.4 References
 
-2.  <a id="Ref_UG-CS" class="anchor"></a>\[UG-CS\] Cybernetica AS. X-Road 6. Central Server User Guide. Document ID: UG-CS.
+1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] Cybernetica AS. X-Road 6. Central Server Installation Guide. Document ID: [IG-CS](ig-cs_x-road_6_central_server_installation_guide.md).
+
+2.  <a id="Ref_UG-CS" class="anchor"></a>\[UG-CS\] Cybernetica AS. X-Road 6. Central Server User Guide. Document ID: [UG-CS](ug-cs_x-road_6_central_server_user_guide.md).
+
+3.  <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 
 ## 2 Key Points and Known Limitations for X-Road Central Server HA Deployment

--- a/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
+++ b/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
@@ -33,7 +33,7 @@ Doc. ID: IG-CSHA
 - [1 Introduction](#1-introduction)
   * [1.1 High Availability for X-Road Central Server](#11-high-availability-for-x-road-central-server)
   * [1.2 Target Audience](#12-target-audience)
-  * [1.3 Terms and abbreviations](#13-terms-and-conditions)
+  * [1.3 Terms and abbreviations](#13-terms-and-abbreviations)
   * [1.4 References](#14-references)
 - [2 Key Points and Known Limitations for X-Road Central Server HA Deployment](#2-key-points-and-known-limitations-for-x-road-central-server-ha-deployment)
 - [3 Requirements and Workflows for HA Configuration](#3-requirements-and-workflows-for-ha-configuration)

--- a/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
+++ b/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
@@ -6,7 +6,7 @@
 
 **X-ROAD 6**
 
-Version: 2.10
+Version: 2.11  
 Doc. ID: IG-SS
 
 ---
@@ -35,6 +35,7 @@ Doc. ID: IG-SS
  13.04.2017 | 2.8     | Added token ID formatting                                       | Cybernetica AS
  25.08.2017 | 2.9     | Update environmental monitoring installation information | Ilkka Seppälä
  15.09.2017 | 2.10    | Added package with configuration specific to Estonia xroad-securityserver-ee | Cybernetica AS
+ 05.03.2018 | 2.11    | Added terms and abbreviations reference and document links
 
 ## Table of Contents
 
@@ -43,7 +44,8 @@ Doc. ID: IG-SS
 - [License](#license)
 - [1 Introduction](#1-introduction)
   * [1.1 Target Audience](#11-target-audience)
-  * [1.2 References](#12-references)
+  * [1.2 Terms and abbreviations](#12-terms-and-abbreviations)
+  * [1.3 References](#13-references)
 - [2 Installation](#2-installation)
   * [2.1 Supported Platforms](#21-supported-platforms)
   * [2.2 Reference Data](#22-reference-data)
@@ -79,11 +81,15 @@ The intended audience of this Installation Guide are X-Road Security server syst
 
 The document is intended for readers with a moderate knowledge of Linux server management, computer networks, and the X-Road working principles.
 
+### 1.2 Terms and abbreviations
 
-### 1.2 References
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
-1.  <a id="Ref_UG-SS" class="anchor"></a>\[UG-SS\] Cybernetica AS. X-Road 6. Security Server User Guide. Document ID UG-SS
+### 1.3 References
 
+1.  <a id="Ref_UG-SS" class="anchor"></a>\[UG-SS\] Cybernetica AS. X-Road 6. Security Server User Guide. Document ID: [UG-SS](ug-ss_x-road_6_security_server_user_guide.md)
+
+2.  <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Installation
 

--- a/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
+++ b/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
@@ -35,7 +35,7 @@ Doc. ID: IG-SS
  13.04.2017 | 2.8     | Added token ID formatting                                       | Cybernetica AS
  25.08.2017 | 2.9     | Update environmental monitoring installation information | Ilkka Seppälä
  15.09.2017 | 2.10    | Added package with configuration specific to Estonia xroad-securityserver-ee | Cybernetica AS
- 05.03.2018 | 2.11    | Added terms and abbreviations reference and document links
+ 05.03.2018 | 2.11    | Added terms and abbreviations reference and document links | Tatu Repo
 
 ## Table of Contents
 

--- a/doc/Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md
+++ b/doc/Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md
@@ -4,7 +4,7 @@
 
 # X-Road: Configuration Proxy Manual
 
-Version: 2.1  
+Version: 2.2  
 Doc. ID: UG-CP
 
 ## Version History
@@ -19,6 +19,7 @@ Doc. ID: UG-CP
 | 09.07.2015 | 1.5     | Repository address updated             |              |
 | 20.09.2015 | 2.0     | Editorial changes made                 |              |
 | 07.06.2017 | 2.1     | System parameter *signature-algorithm-id* replaced with *signature-digest-algorithm-id* | Kristo Heero |
+| 05.03.2018 | 2.2     | Added references, terms and abbreviations reference, document link | Tatu Repo |
 
 ## Table of Contents
 
@@ -26,7 +27,9 @@ Doc. ID: UG-CP
 
 * [1 Introduction](#1-introduction)
     * [1.1 Target Audience](#11-target-audience)
-    * [1.2 X-Road Configuration Proxy](#12-x-road-configuration-proxy)
+    * [1.2 Terms and abbreviations](#12-terms-and-abbreviations)
+    * [1.3 References](#13-references)
+    * [1.4 X-Road Configuration Proxy](#14-x-road-configuration-proxy)
 * [2 Installation](#2-installation)
     * [2.1 Supported Platforms](#21-supported-platforms)
     * [2.2 Reference Data](#22-reference-data)
@@ -58,7 +61,15 @@ The intended audience of this Manual are X-Road system administrators responsibl
 
 The document is intended for readers with a moderate knowledge of Linux server management, computer networks, and the X-Road working principles.
 
-### 1.2 X-Road Configuration Proxy
+### 1.2 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+### 1.3 References
+
+1. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md). 
+
+### 1.4 X-Road Configuration Proxy
 
 The configuration proxy acts as an intermediary between X-Road servers in the matters of global configuration exchange.
 

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -136,7 +136,7 @@ Instructions for the installation and initial configuration of the central serve
 
 ## 1.2 Terms and abbreviations
 
-See X-Road terms and abbreviations documentation \[[TA-TERMS](#13-references)\].
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ## 1.3 References
 

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server User Guide
 
-Version: 2.4  
+Version: 2.5  
 Doc. ID: UG-CS
 
 
@@ -29,6 +29,7 @@ Doc. ID: UG-CS
 | 14.4.2016  | 2.2     | Added chapter for additional configuration options. ||
 | 5.9.2016   | 2.3     | Added instructions for configuring OCSP fetch interval. ||
 | 20.01.2017 | 2.4       | Added license text and version history | Sami Kallio |
+| 05.03.2018 | 2.5     | Added terms and abbreviations reference and document links | Tatu Repo |
 
 ## Table of Contents
 <!-- toc -->
@@ -36,7 +37,8 @@ Doc. ID: UG-CS
   * [License](#license)
 - [1. Introduction](#1-introduction)
   * [1.1 Target Audience](#11-target-audience)
-  * [1.2 References](#12-references)
+  * [1.2 Terms and abbreviations](#12-terms-and-abbreviations)
+  * [1.3 References](#13-references)
 - [2. User Management](#2-user-management)
   * [2.1 User Roles](#21-user-roles)
   * [2.2 Managing the Users](#22-managing-the-users)
@@ -130,18 +132,23 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 The intended audience of this User Guide are X-Road central server administrators who are responsible for everyday management of the X-Road central server.
 
-Instructions for the installation and initial configuration of the central server can be found in the Central Server Installation Guide [CSI]. Instructions for installing the central server in a cluster for achieving high availability can be found in the Central Server High Availability Installation Guide [IG-CSHA].
+Instructions for the installation and initial configuration of the central server can be found in the Central Server Installation Guide [CSI](#13-references). Instructions for installing the central server in a cluster for achieving high availability can be found in the Central Server High Availability Installation Guide [IG-CSHA](#13-references).
 
-## 1.2 References
+## 1.2 Terms and abbreviations
 
-1. [CSI] Cybernetica AS. X-Road 6. Central Server Installation Guide. Document ID: IG-CS
-2. [IG-CSHA] Cybernetica AS. X-Road 6. Central Server High Availability Installation Guide. Document ID: IG-CSHA
-3. [JSON] Introducing JSON, http://json.org/
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#13-references)\].
+
+## 1.3 References
+
+1. [CSI] Cybernetica AS. X-Road 6. Central Server Installation Guide. Document ID: [IG-CS](ig-cs_x-road_6_central_server_installation_guide.md)
+2. [IG-CSHA] Cybernetica AS. X-Road 6. Central Server High Availability Installation Guide. Document ID: [IG-CSHA](ig-csha_x-road_6_ha_installation_guide.md)
+3. [JSON] Introducing JSON, [http://json.org/](http://json.org/)
 4. [SPEC-AL] Cybernetica AS. X-Road: Audit log events. Document ID: SPEC-AL
-5. [SSI] Cybernetica AS. X-Road 6. Security Server Installation Guide. Document ID: IG-SS
-6. [IG-CS] Cybernetica AS. X-Road 6. Central Server Installation Guide. Document ID: IG-CS
-7. [UC-GCONF] Cybernetica AS. X-Road 6: Use Case Model for Global Configuration Distribution. Document ID: UC-GCONF
-8. [RFC-OCSP] Online Certificate Status Protocol – OCSP, https://tools.ietf.org/html/rfc6960
+5. [SSI] Cybernetica AS. X-Road 6. Security Server Installation Guide. Document ID: [IG-SS](ig-ss_x-road_v6_security_server_installation_guide.md)
+6. [IG-CS] Cybernetica AS. X-Road 6. Central Server Installation Guide. Document ID: [IG-CS](ig-cs_x-road_6_central_server_installation_guide.md)
+7. [UC-GCONF] Cybernetica AS. X-Road 6: Use Case Model for Global Configuration Distribution. Document ID: [UC-GCONF](../UseCases/uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md)
+8. [RFC-OCSP] Online Certificate Status Protocol – OCSP, [https://tools.ietf.org/html/rfc6960](https://tools.ietf.org/html/rfc6960)
+9. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 # 2. User Management
 
@@ -233,7 +240,7 @@ The central server provides management services to the security servers that are
 
 A subsystem of an X-Road member acting as a service provider for the management services must be appointed in the central server (see 4.2.1), registered as a client of the management services’ security server (see 4.2.2) and configured to provide the services in the management services’ security server (see 4.2.3).
 
-The management services’ security server must be installed and registered in the central server before the management service provider can be registered as a client of the security server and the management services can be configured (see [SSI]).
+The management services’ security server must be installed and registered in the central server before the management service provider can be registered as a client of the security server and the management services can be configured (see [SSI](#13-references)).
 
 ### 4.2.1 Appointing the Management Service Provider
 
@@ -1034,7 +1041,7 @@ To upload a configuration file from the local file system to the security server
 
 # 14. Audit Log
 
-The central server keeps an audit log of the events performed by the central server administrator. The audit log events are generated by the user interface when the user changes the system’s state or configuration. The user actions are logged regardless of whether the outcome of the action was a success or a failure. The complete list of the audit log events is described in [SPEC-AL].
+The central server keeps an audit log of the events performed by the central server administrator. The audit log events are generated by the user interface when the user changes the system’s state or configuration. The user actions are logged regardless of whether the outcome of the action was a success or a failure. The complete list of the audit log events is described in [SPEC-AL](#13-references).
 
 Actions that change the system’s state or configuration but are not carried out using the user interface are not logged (for example, X-Road software installation and upgrade, user creation and permission granting, and changing of the configuration files in the file system).
 
@@ -1048,7 +1055,7 @@ For example, adding a new member in the central server produces the following lo
 
 `2015-07-03T11:40:52+03:00 my-central-server-host INFO  [X-Road Center UI] 2015-07-03 11:40:52+0300 - {"event":"Add member","user":"admin1", "data":{"memberName":"member1 name","memberClass":"COM", "memberCode":"member1"}}`
 
-The event is present in JSON [JSON] format, in order to ensure machine processability. The field event represents the description of the event, the field user represents the user name of the performer, and the field data represents data related with the event. The failed action event record contains an additional field reason for the error message. For example:
+The event is present in JSON [JSON](#13-references) format, in order to ensure machine processability. The field event represents the description of the event, the field user represents the user name of the performer, and the field data represents data related with the event. The failed action event record contains an additional field reason for the error message. For example:
 
 `2015-07-03T11:51:24+03:00 my-central-server-host INFO  [X-Road Center UI] 2015-07-03 11:51:24+0300 - {"event":"Log in to token failed","user":"admin1", "reason":"PIN incorrect","data":{"tokenId":"0","tokenSerialNumber":null, "tokenFriendlyName":"softToken-0"}}`
 
@@ -1086,9 +1093,9 @@ The X-Road software does not offer special tools for archiving the audit log. Th
 
 # 15. Monitoring
 
-Monitoring is taken to use by installing the monitoring support (see [IG-CS]) and appointing the central monitoring client as specified below.
+Monitoring is taken to use by installing the monitoring support (see [IG-CS](#13-references) and appointing the central monitoring client as specified below.
 
-Identity of central monitoring client (if any) is configured using central server's admin user interface. Configuration is done by updating a specific optional configuration file (see [UC-GCONF]) monitoring-params.xml. This configuration file is distributed to all security servers through the global configuration distribution process (see [UC-GCONF]).
+Identity of central monitoring client (if any) is configured using central server's admin user interface. Configuration is done by updating a specific optional configuration file (see [UC-GCONF](#13-references)) monitoring-params.xml. This configuration file is distributed to all security servers through the global configuration distribution process (see [UC-GCONF](#13-references)).
 
 ```xml
 <tns:conf xmlns:id="http://x-road.eu/xsd/identifiers" xmlns:tns="http://x-road.eu/xsd/xroad.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://x-road.eu/xsd/xroad.xsd">
@@ -1117,9 +1124,9 @@ To disable central monitoring client altogether, update configuration to one whi
 # 16. Additional configuration options
 ## 16.1 Verify next update
 
-For additional robustness the OCSP [RFC-OCSP] response verifier can be configured to skip checking of nextUpdate parameter. By default the checking is turned on and to turn it off the user has to take action.
+For additional robustness the OCSP [RFC-OCSP](#13-references) response verifier can be configured to skip checking of nextUpdate parameter. By default the checking is turned on and to turn it off the user has to take action.
 
-Configuration is done by updating a specific optional configuration file (see [UC-GCONF]) nextupdate-params.xml. This configuration file is distributed to all security servers through the global configuration distribution process (see [UC-GCONF]).
+Configuration is done by updating a specific optional configuration file (see [UC-GCONF](#13-references)) nextupdate-params.xml. This configuration file is distributed to all security servers through the global configuration distribution process (see [UC-GCONF](#13-references)).
 
 ```xml
 <xro:conf xmlns:xro="http://x-road.eu/xsd/xroad.xsd">
@@ -1131,7 +1138,7 @@ With verifyNextUpdate element value “false” the nextUpdate parameter checkin
 
 ## 16.2 OCSP fetch interval
 
-The xroad-signer component has a specific interval how often it downloads new OCSP [RFC-OCSP] responses. By default the fetch interval is configured to 3600 seconds. To use something else than the default value a global configuration extension part (see [UC-GCONF]) of specific format can be uploaded to central server.
+The xroad-signer component has a specific interval how often it downloads new OCSP [RFC-OCSP](#13-references) responses. By default the fetch interval is configured to 3600 seconds. To use something else than the default value a global configuration extension part (see [UC-GCONF](#13-references)) of specific format can be uploaded to central server.
 
 ```xml
 <xro:conf xmlns:xro="http://x-road.eu/xsd/xroad.xsd">

--- a/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
+++ b/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
@@ -6,8 +6,8 @@
 
 **X-ROAD 6**
 
-Version: 2.17  
-15.06.2017
+Version: 2.20  
+05.03.2018  
 Doc. ID: UG-SS
 
 ---
@@ -53,6 +53,7 @@ Doc. ID: UG-SS
  15.06.2017 | 2.17    | Added [Chapter 17](#18-federation) on federation | Olli Lindgren
  25.09.2017 | 2.18    | Added chapter [16 Environmental Monitoring](#16-environmental-monitoring) | Tomi Tolvanen
  17.10.2017 | 2.19    | Added section [16.3 Limiting environmental monitoring remote data set](#163-limiting-environmental-monitoring-remote-data-set)| Joni Laurila
+ 05.03.2018 | 2.20    | Added terms and abbreviations reference, document links, moved concepts to terms and abbreviations. | Tatu Repo 
  
 ## Table of Contents
 
@@ -61,7 +62,7 @@ Doc. ID: UG-SS
 - [License](#license)
 - [1 Introduction](#1-introduction)
   * [1.1 The X-Road Security Server](#11-the-x-road-security-server)
-  * [1.2 X-Road Concepts](#12-x-road-concepts)
+  * [1.2 Terms and abbreviations](#12-terms-and-abbreviations)
   * [1.3 References](#13-references)
 - [2 User Management](#2-user-management)
   * [2.1 User Roles](#21-user-roles)
@@ -188,59 +189,9 @@ To increase the availability of the entire system, the service user's and servic
 
 The security server also depends on a central server, which provides the global configuration.
 
+### 1.2 Terms and abbreviations
 
-### 1.2 X-Road Concepts
-
--   **Global configuration** consists of XML files, which are regularly downloaded by security servers from the X-Road central server. The global configuration includes, among other data, the following:
-
-    -   the addresses and public keys of trust anchors (certification service CAs and timestamping services);
-
-    -   the public keys of intermediate CAs;
-
-    -   the addresses and public keys of OCSP services (if not already available through the certificates' *Authority Information Access* extension*);*
-
-    -   information about X-Road members and their subsystems;
-
-    -   the addresses of the members' security servers registered in X-Road;
-
-    -   information about the security servers' authentication certificates registered in X-Road;
-
-    -   information about the security servers' clients registered in X-Road;
-
-    -   information about global access rights groups;
-
-    -   X-Road system parameters.
-
--   **Member class** groups X-Road members with similar properties under a common unit. E.g., state agencies are grouped under the member class “GOV”, private organizations are grouped under the member class “COM”, etc.
-
--   **Member code**, associated uniquely with a certain X-Road member, is a unique character combination within its particular member class. The member code remains unchanged during the entire lifetime of the member. For example, the member code for organizations and state agencies in Estonia is the Business Registry code.
-
--   **Security server client** is a subsystem of an X-Road member, whose association with a security server is registered in the X-Road governing authority and that uses the security server for using and/or providing X-Road services.
-
--   **Security server owner** is an X-Road member legally responsible for a particular security server. The security server owner is displayed in the list of security server clients ("Configuration" -&gt; "Security Server Clients") in bold font style.
-
--   **Subsystem** represents a part of an X-Road member's information system. X-Road members must declare parts of its information system as subsystems to use or provide X-Road services.
-
-    Subsystems are autonomous in terms of providing and using X-Road services.
-
-    -   The access rights of an X-Road members’ subsystems are independent – access rights given to one subsystem do not affect the access rights of the members’ other subsystems.
-
-    -   Services provided by a subsystem are independent of the services provided by the members’ other subsystems.
-
-    To sign the messages sent by a subsystem when using or providing X-Road services, the signing certificate of the member that manages the subsystem is used. An X-Road member can associate several different subsystems with one security server, and one subsystem can be associated with several security servers.
-
--   **X-Road certificate** is issued by a certification service provider that has been approved in the X-Road governing authority. An X-Road certificate is either:
-
-    -   a **signing certificate**, which is issued to X-Road members and which the security servers use to digitally sign the mediated data or
-
-    -   an **authentication certificate**, which is issued to security servers and which is used to establish the secure communications channel between security servers.
-
--   **X-Road instance** identifier helps to distinguish between different X-Road instances. Each instance is assigned an identifying code. E.g. the code for the Estonian development instance is “ee-dev” and the code for production instance is “EE”.
-
--   **X-Road member** is a legal (or physical) person who has joined the X-Road and uses the functionality provided by the X-Road in the capability of service provider and/or user.
-
--   **X-Road messages** are service requests and responses described according to the X-Road Message Protocol (see \[[PR-MESS](#Ref_PR-MESS)\]), that are exchanged between the information systems using or providing services and the security servers.
-
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
@@ -258,17 +209,17 @@ The security server also depends on a central server, which provides the global 
 5.  <a id="Ref_JSON" class="anchor"></a>\[JSON\] Introducing JSON,  
     <http://json.org/>
 
-6.  <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Message Protocol v4.0. Document ID: PR-MESS
+6.  <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Message Protocol v4.0. Document ID: [PR-MESS](../Protocols/pr-mess_x-road_message_protocol.md)
 
 7.  <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] Cybernetica AS. X-Road: Audit log events. Document ID: SPEC-AL
 
-8.  <a id="Ref_PR-OPMON" class="anchor"></a>\[PR-OPMON\] Cybernetica AS. X-Road: Operational Monitoring Protocol. Document ID: PR-OPMON
+8.  <a id="Ref_PR-OPMON" class="anchor"></a>\[PR-OPMON\] Cybernetica AS. X-Road: Operational Monitoring Protocol. Document ID: [PR-OPMON](../OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md)
 
-9.  <a id="Ref_PR-OPMONJMX" class="anchor"></a>\[PR-OPMONJMX\] Cybernetica AS. X-Road: Operational Monitoring JMX Protocol. Document ID: PR-OPMONJMX
+9.  <a id="Ref_PR-OPMONJMX" class="anchor"></a>\[PR-OPMONJMX\] Cybernetica AS. X-Road: Operational Monitoring JMX Protocol. Document ID: [PR-OPMONJMX](../OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md)
 
-10. <a id="Ref_UG-OPMONSYSPAR" class="anchor"></a>\[UG-OPMONSYSPAR\] Cybernetica AS. X-Road: Operational Monitoring System Parameters. Document ID: PR-OPMONSYSPAR
+10. <a id="Ref_UG-OPMONSYSPAR" class="anchor"></a>\[UG-OPMONSYSPAR\] Cybernetica AS. X-Road: Operational Monitoring System Parameters. Document ID: [PR-OPMONSYSPAR](../OperationalMonitoring/Manuals/ug-opmonsyspar_x-road_operational_monitoring_system_parameters_Y-1099-1.md)
 
-11. <a id="Ref_IG-SS" class="anchor"></a>\[IG-SS\] Cybernetica AS. X-Road: Security Server Installation Guide. Document ID: IG-SS
+11. <a id="Ref_IG-SS" class="anchor"></a>\[IG-SS\] Cybernetica AS. X-Road: Security Server Installation Guide. Document ID: [IG-SS](ig-ss_x-road_v6_security_server_installation_guide.md)
 
 12. <a id="Ref_JMX" class="anchor"></a>\[JMX\] Monitoring and Management Using JMX Technology,  
     <http://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html>
@@ -282,15 +233,13 @@ The security server also depends on a central server, which provides the global 
 15. <a id="Ref_ZABBIX-API" class="anchor"></a>\[ZABBIX-API\] Zabbix API,  
     <https://www.zabbix.com/documentation/3.0/manual/api>
 
-16. <a id="Ref_ARC-ENVMON" class="anchor"></a>\[ARC-ENVMON\] X-Road: Environmental Monitoring Architecture. Document ID: ARC-ENVMON.  
-    <https://github.com/vrk-kpa/X-Road/blob/develop/doc/EnvironmentalMonitoring/Monitoring-architecture.md>
+16. <a id="Ref_ARC-ENVMON" class="anchor"></a>\[ARC-ENVMON\] X-Road: Environmental Monitoring Architecture. Document ID: [ARC-ENVMON](../EnvironmentalMonitoring/Monitoring-architecture.md).
 
-17. <a id="Ref_PR-ENVMONMES" class="anchor"></a>\[PR-ENVMONMES\] X-Road: Environmental Monitoring Messages. Document ID: PR-ENVMONMES.  
-    <https://github.com/vrk-kpa/X-Road/blob/develop/doc/EnvironmentalMonitoring/Monitoring-messages.md>
+17. <a id="Ref_PR-ENVMONMES" class="anchor"></a>\[PR-ENVMONMES\] X-Road: Environmental Monitoring Messages. Document ID: [PR-ENVMONMES](../EnvironmentalMonitoring/Monitoring-messages.md).
 
-18. <a id="Ref_MONITORING_XSD" class="anchor"></a>\[MONITORING_XSD\] X-Road XML schema for monitoring extension.  
-    <https://github.com/vrk-kpa/X-Road/blob/develop/src/addons/proxymonitor/common/src/main/resources/monitoring.xsd>
+18. <a id="Ref_MONITORING_XSD" class="anchor"></a>\[MONITORING_XSD\] X-Road XML schema for monitoring extension. [monitoring.xsd](../../src/addons/proxymonitor/common/src/main/resources/monitoring.xsd).
 
+19. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 User Management
 

--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -67,12 +67,12 @@ Doc. ID: UG-SYSPAR
   * [4.1 System Parameters in the Configuration File](#41-system-parameters-in-the-configuration-file)
     + [4.1.1 Common parameters: `[common]`](#411-common-parameters-common)
     + [4.1.2 Center parameters: `[center]`](#412-center-parameters-center)
-    + [4.1.3 Signer parameters: `[signer]`](#413-signer-parameters-signer-1)
+    + [4.1.3 Signer parameters: `[signer]`](#413-signer-parameters-signer)
   * [4.2 System Parameters in the Database](#42-system-parameters-in-the-database)
   * [4.3 Global Configuration Generation Interval Parameter](#43-global-configuration-generation-interval-parameter)
 - [5 Configuration Proxy System Parameters](#5-configuration-proxy-system-parameters)
     + [5.1 Configuration proxy module parameters: `[configuration-proxy]`](#51-configuration-proxy-module-parameters-configuration-proxy)
-    + [5.2 Signer parameters: `[signer]`](#52-signer-parameters-signer-2)
+    + [5.2 Signer parameters: `[signer]`](#52-signer-parameters-signer)
 
 <!-- tocstop -->
 
@@ -109,7 +109,7 @@ The system parameters specify various characteristics of the system, such as por
 
 ### 2.1 Changing the System Parameter Values in Configuration Files
 
-The configuration files are INI files [[INI](#Ref_INI)], where each section contains parameters for a particular server component.
+The configuration files are INI files \[[INI](#Ref_INI)\], where each section contains parameters for a particular server component.
 
 In order to override the default values of system parameters, create or edit the file
 
@@ -161,7 +161,7 @@ To restore the default value of a system parameter, delete the parameter from th
 
 ### 2.3 Changing the Global Configuration Generation Interval in the Central Server
 
-In order to override the default value of the global configuration generation interval, edit the cron expression [[CRON](#Ref_CRON)] in the file
+In order to override the default value of the global configuration generation interval, edit the cron expression \[[CRON](#Ref_CRON)\] in the file
 
 	/etc/cron.d/xroad-center
 
@@ -206,7 +206,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | jetty-serverproxy-configuration-file             | /etc/xroad/jetty/serverproxy.xml           |   |   | Absolute filename of the Jetty configuration file for the service provider's security server. For more information about configuring Jetty server, see https://wiki.eclipse.org/Jetty/Reference/jetty.xml\_usage. |
 | jetty-ocsp-responder-configuration-file          | /etc/xroad/jetty/ocsp-responder.xml        |   |   | Absolute filename of the Jetty configuration file for the OCSP responder of the service provider's security server. For more information about configuring Jetty server, see https://wiki.eclipse.org/Jetty/Reference/jetty.xml\_usage. |
 | ssl-enabled                                      | true                                       |   |   | If true, TLS is used for connections between the service client's and service provider's security servers. |
-| client-tls-ciphers                               | See [1]                                    | See [1] |   | TLS ciphers enabled on the client-side interfaces (for both incoming and outgoing requests). (since version 6.7) |
+| client-tls-ciphers                               | See [1](#Ref_note1)                        | See [1](#Ref_note1) |   | TLS ciphers enabled on the client-side interfaces (for both incoming and outgoing requests). (since version 6.7) |
 | client-tls-protocols                             | TLSv1.2,TLSv1.1                            | TLSv1.2 |   | TLS protocols enabled on the client-side interfaces (for both incoming and outgoing requests) (since version 6.7) |
 | server-connector-max-idle-time                   | 0                                          | 120000 |   | The maximum time (in milliseconds) that connections from a service consuming security server to a service providing security server are allowed to be idle before the provider security server starts closing them. Value of 0 means that an infinite idle time is allowed. A non-zero value should allow some time for a pooled connection to be idle, if  pooled connections are to be supported.|
 | server-connector-so-linger                       | -1                                         |   |   | The SO_LINGER time (in seconds) at the service providing security server end for connections between security servers.<br>A value larger than 0 means that upon closing a connection, the system will allow SO_LINGER seconds for the transmission and acknowledgement of all data written to the peer, at which point the socket is closed gracefully. Upon reaching the linger timeout, the socket is closed forcefully, with a TCP RST. Enabling the option with a timeout of zero does a forceful close immediately.<br>Value of -1 disables the forceful close.|
@@ -364,7 +364,7 @@ The global configuration generation interval parameter regulates the timing for 
 
 	/etc/cron.d/xroad-center
 
-The file is deployed during X-Road installation and by default has following content (see exact cron specifications) [[CRONHOW](#Ref_CRONHOW)]:
+The file is deployed during X-Road installation and by default has following content (see exact cron specifications) \[[CRONHOW](#Ref_CRONHOW)\]:
 
 	#!/bin/sh
 	* * * * * xroad curl http://127.0.0.1:8084/managementservice/gen_conf 2>1 >/dev/null;
@@ -395,7 +395,7 @@ This chapter describes the system parameters used by the X-Road configuration pr
 | ocsp-cache-path                | /var/cache/xroad                        | Absolute path to the directory where the cached OCSP responses are stored. |
 | enforce-token-pin-policy       | false                                   | Controls enforcing the token pin policy. When set to true, software token pin is required to be at least 10 ASCII characters from at least tree character classes (lowercase letters, uppercase letters, digits, special characters). (since version 6.7.7) |
 
-[1] Default value for proxy.client-tls-ciphers.
+<a id="Ref_note1"></a>[1] Default value for proxy.client-tls-ciphers.
 >TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,

--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -1,6 +1,6 @@
 # X-Road: System Parameters User Guide
 
-Version: 2.29  
+Version: 2.30  
 Doc. ID: UG-SYSPAR
 
 | Date       | Version  | Description                                                                  | Author             |
@@ -39,38 +39,40 @@ Doc. ID: UG-SYSPAR
 | 22.11.2017 | 2.27     | Default changed to vanilla. New colums added for FI and EE values. | Antti Luoma |
 | 02.01.2018 | 2.28     | Added proxy parameter allow-get-wsdl-request. | Ilkka Seppälä |
 | 29.01.2018 | 2.29     | Removed proxy parameter client-fastest-connecting-ssl-use-uri-cache. Added proxy parameter client-fastest-connecting-ssl-uri-cache-period. | Ilkka Seppälä |
+| 05.03.2018 | 2.30     | Added reference to terms and abbreviations, modified reference handling, added numbering. | Tatu Repo |
 
 ## Table of Contents
 
 <!-- toc -->
 
   * [License](#license)
-- [Introduction](#introduction)
-  * [References](#references)
-- [Changing the System Parameter Values](#changing-the-system-parameter-values)
-  * [Changing the System Parameter Values in Configuration Files](#changing-the-system-parameter-values-in-configuration-files)
-  * [Changing the System Parameter Values in the Central Server Database](#changing-the-system-parameter-values-in-the-central-server-database)
-  * [Changing the Global Configuration Generation Interval in the Central Server](#changing-the-global-configuration-generation-interval-in-the-central-server)
-- [Security Server System Parameters](#security-server-system-parameters)
-  * [Common parameters : `[common]`](#common-parameters--common)
-  * [Proxy parameters: `[proxy]`](#proxy-parameters-proxy)
-  * [Proxy User Interface parameters: `[proxy-ui]`](#proxy-user-interface-parameters-proxy-ui)
-  * [Signer parameters: `[signer]`](#signer-parameters-signer)
-  * [Anti-DOS parameters: `[anti-dos]`](#anti-dos-parameters-anti-dos)
-  * [Configuration Client parameters: `[configuration-client]`](#configuration-client-parameters-configuration-client)
-  * [Message log add-on parameters: `[message-log]`](#message-log-add-on-parameters-message-log)
-    + [Note on logged X-Road message headers](#note-on-logged-x-road-message-headers)
-  * [Environmental monitoring add-on configuration parameters: `[env-monitor]`](#environmental-monitoring-add-on-configuration-parameters-env-monitor)
-- [Central Server System Parameters](#central-server-system-parameters)
-  * [System Parameters in the Configuration File](#system-parameters-in-the-configuration-file)
-    + [Common parameters: `[common]`](#common-parameters-common)
-    + [Center parameters: `[center]`](#center-parameters-center)
-    + [Signer parameters: `[signer]`](#signer-parameters-signer-1)
-  * [System Parameters in the Database](#system-parameters-in-the-database)
-  * [Global Configuration Generation Interval Parameter](#global-configuration-generation-interval-parameter)
-- [Configuration Proxy System Parameters](#configuration-proxy-system-parameters)
-    + [Configuration proxy module parameters: `[configuration-proxy]`](#configuration-proxy-module-parameters-configuration-proxy)
-    + [Signer parameters: `[signer]`](#signer-parameters-signer-2)
+- [1 Introduction](#1-introduction)
+  * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+  * [1.2 References](#12-references)
+- [2 Changing the System Parameter Values](#2-changing-the-system-parameter-values)
+  * [2.1 Changing the System Parameter Values in Configuration Files](#21-changing-the-system-parameter-values-in-configuration-files)
+  * [2.2 Changing the System Parameter Values in the Central Server Database](#22-changing-the-system-parameter-values-in-the-central-server-database)
+  * [2.3 Changing the Global Configuration Generation Interval in the Central Server](#23-changing-the-global-configuration-generation-interval-in-the-central-server)
+- [3 Security Server System Parameters](#3-security-server-system-parameters)
+  * [3.1 Common parameters : `[common]`](#31-common-parameters--common)
+  * [3.2 Proxy parameters: `[proxy]`](#32-proxy-parameters-proxy)
+  * [3.3 Proxy User Interface parameters: `[proxy-ui]`](#33-proxy-user-interface-parameters-proxy-ui)
+  * [3.4 Signer parameters: `[signer]`](#34-signer-parameters-signer)
+  * [3.5 Anti-DOS parameters: `[anti-dos]`](#35-anti-dos-parameters-anti-dos)
+  * [3.6 Configuration Client parameters: `[configuration-client]`](#36-configuration-client-parameters-configuration-client)
+  * [3.7 Message log add-on parameters: `[message-log]`](#37-message-log-add-on-parameters-message-log)
+    + [3.7.1 Note on logged X-Road message headers](#371-note-on-logged-x-road-message-headers)
+  * [3.8 Environmental monitoring add-on configuration parameters: `[env-monitor]`](#38-environmental-monitoring-add-on-configuration-parameters-env-monitor)
+- [4 Central Server System Parameters](#4-central-server-system-parameters)
+  * [4.1 System Parameters in the Configuration File](#41-system-parameters-in-the-configuration-file)
+    + [4.1.1 Common parameters: `[common]`](#411-common-parameters-common)
+    + [4.1.2 Center parameters: `[center]`](#412-center-parameters-center)
+    + [4.1.3 Signer parameters: `[signer]`](#413-signer-parameters-signer-1)
+  * [4.2 System Parameters in the Database](#42-system-parameters-in-the-database)
+  * [4.3 Global Configuration Generation Interval Parameter](#43-global-configuration-generation-interval-parameter)
+- [5 Configuration Proxy System Parameters](#5-configuration-proxy-system-parameters)
+    + [5.1 Configuration proxy module parameters: `[configuration-proxy]`](#51-configuration-proxy-module-parameters-configuration-proxy)
+    + [5.2 Signer parameters: `[signer]`](#52-signer-parameters-signer-2)
 
 <!-- tocstop -->
 
@@ -78,31 +80,36 @@ Doc. ID: UG-SYSPAR
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
-# Introduction
+## 1 Introduction
 
 This document describes the system parameters of the X-Road components – of the security server, the central server and the configuration proxy. Additionally, changing the default values of the system parameters are explained.
 Please note the term 'vanilla' in the documentation. In X-Road context vanilla means the X-Road without any of the country specific customizations, settings etc. The vanilla version of X-Road security server is installed with xroad-securityserver package. The country specific versions are installed with xroad-securityserver-XX where XX is the country code f.ex. FI or EE.
 
-## References
+### 1.1 Terms and abbreviations
 
-1.  \[INI\] INI file, [*http://en.wikipedia.org/wiki/INI\_file*](http://en.wikipedia.org/wiki/INI_file)
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
-2.  \[CRON\] Quartz Scheduler
-    CRON expression,
-    *http://www.quartz-scheduler.org/documentation/quartz-2.1.x/tutorials/crontrigger.html*
-3.  <a name="Ref_PR-MESS"></a>\[PR-MESS\] [X-Road Message Protocol v. 4.0](../Protocols/pr-mess_x-road_message_protocol.md)
-4.  <a name="Ref_PR-TARGETSS"></a>\[PR-TARGETSS\] [Security Server Targeting Extension for the X-Road Message Protocol](../Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md)
-5.  <a name="Ref_PR-SECTOKEN"></a>\[PR-SECTOKEN\] [Security Token Extension for the X-Road Message Protocol](../Protocols/SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md)
+### 1.2 References
 
-# Changing the System Parameter Values
+1.  <a id="Ref_INI"></a>\[INI\] INI file, [http://en.wikipedia.org/wiki/INI_file](http://en.wikipedia.org/wiki/INI_file).
+2.  <a id="Ref_CRON"></a>\[CRON\] Quartz Scheduler
+    CRON expression, [http://www.quartz-scheduler.org/documentation/quartz-2.1.x/tutorials/crontrigger.html](http://www.quartz-scheduler.org/documentation/quartz-2.1.x/tutorials/crontrigger.html).
+3.  <a id="Ref_PR-MESS"></a>\[PR-MESS\] [X-Road Message Protocol v. 4.0](../Protocols/pr-mess_x-road_message_protocol.md).
+4.  <a id="Ref_PR-TARGETSS"></a>\[PR-TARGETSS\] [Security Server Targeting Extension for the X-Road Message Protocol](../Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md).
+5.  <a id="Ref_PR-SECTOKEN"></a>\[PR-SECTOKEN\] [Security Token Extension for the X-Road Message Protocol](../Protocols/SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md).
+6.  <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] [X-Road Terms and Abbreviations](../terms_x-road_docs.md).
+7.  <a id="Ref_CRONMAN"></a>\[CRONMAN\] [http://linux.die.net/man/8/cron](http://linux.die.net/man/8/cron). 
+8.  <a id="Ref_CRONHOW"></a>\[CRONHOW\] Cron format specifications [https://help.ubuntu.com/community/CronHowto](https://help.ubuntu.com/community/CronHowto).
+
+## 2 Changing the System Parameter Values
 
 The system parameters specify various characteristics of the system, such as port numbers, timeouts and paths to files on disk. The system parameters of the X-Road components are mainly stored in configuration files. Additionally, X-Road central server stores some system parameters in the database.
 
 **Changing the values of the system parameters is strongly discouraged, since it may cause unexpected system behaviour.**
 
-## Changing the System Parameter Values in Configuration Files
+### 2.1 Changing the System Parameter Values in Configuration Files
 
-The configuration files are INI files \[INI\], where each section contains parameters for a particular server component.
+The configuration files are INI files [[INI](#Ref_INI)], where each section contains parameters for a particular server component.
 
 In order to override the default values of system parameters, create or edit the file
 
@@ -131,7 +138,7 @@ Multiple parameters can be configured under the same section:
 
 **WARNING! The value of the parameter is not validated, thus care must be taken when changing the value. For example, setting the port number to a non-numeric value in the configuration will cause the system to crash.**
 
-## Changing the System Parameter Values in the Central Server Database
+### 2.2 Changing the System Parameter Values in the Central Server Database
 
 The central server database can be accessed with the psql utility using the following command (password: *centerui*):
 
@@ -152,9 +159,9 @@ To restore the default value of a system parameter, delete the parameter from th
 **NB! Modifying or deleting system parameters other than the ones listed in section** [System Parameters in the Database](#system-parameters-in-the-database) **will cause the system to crash.**
 
 
-## Changing the Global Configuration Generation Interval in the Central Server
+### 2.3 Changing the Global Configuration Generation Interval in the Central Server
 
-In order to override the default value of the global configuration generation interval, edit the cron expression[1] in the file
+In order to override the default value of the global configuration generation interval, edit the cron expression [[CRON](#Ref_CRON)] in the file
 
 	/etc/cron.d/xroad-center
 
@@ -167,18 +174,18 @@ The default contents of the file are the following:
 
 The configuration generation interval must be shorter than the value of global configuration expiration interval (*confExpireIntervalSeconds*, see section 4.2 ), or else the configuration downloaded by the configuration clients (security servers or configuration proxies) will always expire before valid configuration becomes available. It is highly recommended that the global configuration generation interval is multiple times smaller than the global configuration expiration interval.
 
-# Security Server System Parameters
+## 3 Security Server System Parameters
 
 This chapter describes the system parameters used by the components of the X-Road security server. For instructions on how to change the parameter values, see section [Changing the System Parameter Values in Configuration Files](#changing-the-system-parameter-values-in-configuration-files).
 
-## Common parameters : `[common]`
+### 3.1 Common parameters : `[common]`
 
 | **Parameter**                                    | **Vanilla value**                          | **Description**   |
 |--------------------------------------------------|--------------------------------------------|------------------ |
 | configuration-path                               | /etc/xroad/globalconf/                     | Absolute path to the directory where global configuration is stored.|
 | temp-files-path                                  | /var/tmp/xroad/                            | Absolute path to the directory where temporary files are stored. |
 
-## Proxy parameters: `[proxy]`
+### 3.2 Proxy parameters: `[proxy]`
 
 | **Parameter**                                    | **Vanilla value**                          | **FI-package value** | **EE-package value** | **Description** |
 |--------------------------------------------------|--------------------------------------------|----------------------|----------------------|-----------------|
@@ -199,7 +206,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | jetty-serverproxy-configuration-file             | /etc/xroad/jetty/serverproxy.xml           |   |   | Absolute filename of the Jetty configuration file for the service provider's security server. For more information about configuring Jetty server, see https://wiki.eclipse.org/Jetty/Reference/jetty.xml\_usage. |
 | jetty-ocsp-responder-configuration-file          | /etc/xroad/jetty/ocsp-responder.xml        |   |   | Absolute filename of the Jetty configuration file for the OCSP responder of the service provider's security server. For more information about configuring Jetty server, see https://wiki.eclipse.org/Jetty/Reference/jetty.xml\_usage. |
 | ssl-enabled                                      | true                                       |   |   | If true, TLS is used for connections between the service client's and service provider's security servers. |
-| client-tls-ciphers                               | See [2]                                    | See [2] |   | TLS ciphers enabled on the client-side interfaces (for both incoming and outgoing requests). (since version 6.7) |
+| client-tls-ciphers                               | See [1]                                    | See [1] |   | TLS ciphers enabled on the client-side interfaces (for both incoming and outgoing requests). (since version 6.7) |
 | client-tls-protocols                             | TLSv1.2,TLSv1.1                            | TLSv1.2 |   | TLS protocols enabled on the client-side interfaces (for both incoming and outgoing requests) (since version 6.7) |
 | server-connector-max-idle-time                   | 0                                          | 120000 |   | The maximum time (in milliseconds) that connections from a service consuming security server to a service providing security server are allowed to be idle before the provider security server starts closing them. Value of 0 means that an infinite idle time is allowed. A non-zero value should allow some time for a pooled connection to be idle, if  pooled connections are to be supported.|
 | server-connector-so-linger                       | -1                                         |   |   | The SO_LINGER time (in seconds) at the service providing security server end for connections between security servers.<br>A value larger than 0 means that upon closing a connection, the system will allow SO_LINGER seconds for the transmission and acknowledgement of all data written to the peer, at which point the socket is closed gracefully. Upon reaching the linger timeout, the socket is closed forcefully, with a TCP RST. Enabling the option with a timeout of zero does a forceful close immediately.<br>Value of -1 disables the forceful close.|
@@ -222,14 +229,14 @@ This chapter describes the system parameters used by the components of the X-Roa
 | actorsystem-port                                 | 5567                                       |   |   | The (localhost) port where the proxy actorsystem binds to. Used for communicating with xroad-signer and xroad-monitor. |
 | allow-get-wsdl-request                           | false                                      |   |   | Whether to allow getWsdl metaservice to be called with HTTP/HTTPS GET method. |
 
-## Proxy User Interface parameters: `[proxy-ui]`
+### 3.3 Proxy User Interface parameters: `[proxy-ui]`
 
 | **Parameter**                                    | **Vanilla value**                          | **Description** |
 |--------------------------------------------------|--------------------------------------------|-----------------|
 | wsdl-validator-command                           |                                            | The command to validate the given X-Road service WSDL. The command script must:<br/>a) read the WSDL from the URI given as an argument or from standard input (*stdin*) if no arguments are given,<br/>b) return exit code 0 on success,<br/>c) return exit code 0 and write warnings to the standard error (*stderr*), if warnings occurs,<br/>d) return exit code other then 0 and write error messages to the standard error (*stderr*), if errors occurs.<br/>Defaults to no operation. |
 | auth-cert-reg-signature-digest-algorithm-id      | SHA-512                                    | Signature digest algorithm used for generating authentication certificate registration request.<br/>Possible values are<br/>-   SHA-256,<br/>-   SHA-384,<br/>-   SHA-512. |
 
-## Signer parameters: `[signer]`
+### 3.4 Signer parameters: `[signer]`
 
 | **Parameter**                                    | **Vanilla value**                          | **FI-package value** | **EE-package value** | **Description** |
 |--------------------------------------------------|--------------------------------------------|----------------------|----------------------|-----------------|
@@ -242,7 +249,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | key-length                                       | 2048                                       |   |   | Key length for generating authentication and signing keys (since version 6.7) |
 | csr-signature-digest-algorithm                   | SHA-256                                    |   |   | Certificate Signing Request signature digest algorithm.<br/>Possible values are<br/>-   SHA-256,<br/>-   SHA-384,<br/>-   SHA-512. |
 
-## Anti-DOS parameters: `[anti-dos]`
+### 3.5 Anti-DOS parameters: `[anti-dos]`
 
 | **Parameter**                                    | **Vanilla value**                          | **Description** |
 |--------------------------------------------------|--------------------------------------------|-----------------|
@@ -252,7 +259,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | max-parallel-connections                         | 5000                                       | Maximum number of parallel connections for AntiDOS. |
 | min-free-file-handles                            | 100                                        | Minimum amount of free file handles in the system for accepting new connections. At least one free file handle must be available to accept a new connection. |
 
-## Configuration Client parameters: `[configuration-client]`
+### 3.6 Configuration Client parameters: `[configuration-client]`
 
 | **Parameter**                                    | **Vanilla value**                          | **Description** |
 |--------------------------------------------------|--------------------------------------------|-----------------|
@@ -261,7 +268,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | admin-port                                       | 5675                                       | TCP port on which the configuration client process listens for admin commands. |
 | allowed-federations                              | none                                       | A comma-separated list of case-insensitive X-Road instances that fetching configuration anchors is allowed for. This enables federation with the listed instances if the X-Road instance is already federated at the central server level . Special value *none*, if present, disables all federation (the default value), while *all* allows all federations if *none* is not present. Example: *allowed-federations=ee,sv* allows federation with example instances *EE* and *Sv* while *allowed-federations=all,none* disables federation. X-Road services `xroad-confclient` and `xroad-proxy` need to be restarted (in that order) for the setting change to take effect.|
 
-## Message log add-on parameters: `[message-log]`
+### 3.7 Message log add-on parameters: `[message-log]`
 
 | **Parameter**                                    | **Vanilla value**                          | **FI-package value** | **EE-package value** | **Description** |
 |--------------------------------------------------|--------------------------------------------|----------------------|----------------------|-----------------|
@@ -271,10 +278,10 @@ This chapter describes the system parameters used by the components of the X-Roa
 | disabled-body-logging-local-producer-subsystems  |                                            |   |   | Same as enabled-body-logging-local-producer-subsystems, but this parameter is used when soap-body-logging = true. |
 | disabled-body-logging-remote-producer-subsystems |                                            |   |   | Same as enabled-body-logging-remote-producer-subsystems, but this parameter is used when soap-body-logging = true. |
 | acceptable-timestamp-failure-period              | 14400                                      | 18000   |   | Defines the time period (in seconds) for how long is time-stamping allowed to fail (for whatever reasons) before the message log stops accepting any more messages (and consequently the security server stops accepting requests). Set to 0 to disable this check. The value of this parameter should not be lower than the value of the central server system parameter *timeStampingIntervalSeconds.* |
-| archive-interval                                 | 0 0 0/6 1/1 \* ? \*                        |   |   | CRON expression \[CRON\] defining the interval of archiving the time-stamped messages. |
+| archive-interval                                 | 0 0 0/6 1/1 \* ? \*                        |   |   | CRON expression \[[CRON](#Ref_CRON)\] defining the interval of archiving the time-stamped messages. |
 | archive-max-filesize                             | 33554432                                   |   |   | Maximum size for archived files in bytes. Reaching the maximum value triggers file rotation. |
 | archive-path                                     | /var/lib/xroad                             |   |   | Absolute path to the directory where time-stamped log records are archived. |
-| clean-interval                                   | 0 0 0/12 1/1 \* ? \*                       |   |   | CRON expression \[CRON\] for deleting any time-stamped and archived records that are older than *message-log.keep-records-for* from the database. |
+| clean-interval                                   | 0 0 0/12 1/1 \* ? \*                       |   |   | CRON expression \[[CRON](#Ref_CRON)\] for deleting any time-stamped and archived records that are older than *message-log.keep-records-for* from the database. |
 | hash-algo-id                                     | SHA-512                                    |   |   | The algorithm identifier used for hashing in the message log.<br/>Possible values are<br/>-   SHA-224,<br/>-   SHA-256,<br/>-   SHA-384,<br/>-   SHA-512. |
 | keep-records-for                                 | 30                                         |   |   | Number of days to keep time-stamped and archived records in the database of the security server. If a time-stamped and archived message record is older than this value, the record is deleted from the database. |
 | timestamp-immediately                            | false                                      |   |   | If true, the time-stamp is created synchronously for each request message. This is a security policy requirement to guarantee the time-stamp at the time of logging the message. |
@@ -283,7 +290,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | timestamper-client-read-timeout                  | 60000                                      |   |   | The timestamper client read timeout in milliseconds. A timeout of zero is interpreted as an infinite timeout. |
 | archive-transaction-batch                        | 10000                                      |   |   | Size of transaction batch for archiving messagelog. This size is not exact because it will always make sure that last archived batch includes timestamp also (this might mean that it will go over transaction size).
 
-### Note on logged X-Road message headers
+#### 3.7.1 Note on logged X-Road message headers
 If the messagelog add-on has the SOAP body logging disabled, only a preconfigured set of the SOAP headers will be included in the message log.
 
 The logged SOAP headers are the X-Road message headers listed in [Chapter 2.2](../Protocols/pr-mess_x-road_message_protocol.md#22-message-headers) of
@@ -291,7 +298,7 @@ the X-Road Message Protocol document \[[PR-MESS](#Ref_PR-MESS)\], as well as the
 extension's [XML schema](http://x-road.eu/xsd/representation.xsd). The security server targeting extension for the X-Road message protocol
 \[[PR-TARGETSS](#Ref_PR-TARGETSS)\] or the Security Token Extension \[[PR-SECTOKEN](#Ref_PR-SECTOKEN)\] will not be included in the message log.
 
-## Environmental monitoring add-on configuration parameters: `[env-monitor]`
+### 3.8 Environmental monitoring add-on configuration parameters: `[env-monitor]`
 
 | **Parameter**                                    | **Vanilla value**                          | **Description** |
 |--------------------------------------------------|--------------------------------------------|-----------------|
@@ -302,23 +309,23 @@ extension's [XML schema](http://x-road.eu/xsd/representation.xsd). The security 
 | certificate-info-sensor-interval                 | 86400                                      | Interval of certificate information sensor in seconds. How often certificate data is collected. The first collection is always done after a delay of 10 seconds. |
 | limit-remote-data-set                            | false                                      | On/Off switch for filtering out optional monitoring data. With flag set to true, only security server owner can request and get full data set. |
 
-# Central Server System Parameters
+## 4 Central Server System Parameters
 
 The system parameters described in this chapter are used by the X-Road central server, except for the parameters *ocspFreshnessSeconds* and *timeStampingIntervalSeconds.*
 
 The values of *ocspFreshnessSeconds* and *timeStampingIntervalSeconds* are distributed to the security servers via the global configuration. These parameters determine the interval of calling OCSP responder services and time-stamping services (respectively) by the security servers.
 
-## System Parameters in the Configuration File
+### 4.1 System Parameters in the Configuration File
 
 For instructions on how to change the parameter values, see section [Changing the System Parameter Values in Configuration Files](#changing-the-system-parameter-values-in-configuration-files).
 
-### Common parameters: `[common]`
+#### 4.1.1 Common parameters: `[common]`
 
 | **Server component** | **Name**                | **Vanilla value**    | **Description**   |
 |----------------------|-------------------------|----------------------|-------------------|
 | common               | temp-files-path         | /var/tmp/xroad/      | Absolute path to the directory where temporary files are stored. |
 
-### Center parameters: `[center]`
+#### 4.1.2 Center parameters: `[center]`
 
 | **Name**                | **Vanilla value**                       | **Description**       |
 |-------------------------|-----------------------------------------|-----------------------|
@@ -330,7 +337,7 @@ For instructions on how to change the parameter values, see section [Changing th
 | trusted-anchors-allowed | false                                   | True if federation is allowed for this X-Road instance. |
 | minimum-global-configuration-version | 2                          | Minimum supported global configuration version on central server. Change this if old global configuration versions need to be supported. |
 
-### Signer parameters: `[signer]`
+#### 4.1.3 Signer parameters: `[signer]`
 
 | **Name**                | **Vanilla value**                      | **Description** |
 |-------------------------|----------------------------------------|-----------------|
@@ -338,7 +345,7 @@ For instructions on how to change the parameter values, see section [Changing th
 | ocsp-cache-path                | /var/cache/xroad                | Absolute path to the directory where the cached OCSP responses are stored. |
 | enforce-token-pin-policy       | false                           | Controls enforcing the token pin policy. When set to true, software token pin is required to be at least 10 ASCII characters from at least tree character classes (lowercase letters, uppercase letters, digits, special characters). (since version 6.7.7) |
 
-## System Parameters in the Database
+### 4.2 System Parameters in the Database
 
 This section describes the system parameters used by the X-Road central server. For instructions on how to change the parameter values, see section [Changing the System Parameter Values in the Central Server Database](#changing-the-system-parameter-values-in-the-central-server-database).
 
@@ -351,24 +358,24 @@ This section describes the system parameters used by the X-Road central server. 
 | ocspFreshnessSeconds        | integer        | 3600                                     | Defines the validity period (in seconds) for the OCSP responses retrieved from the OCSP responders. OCSP responses older than the validity period are considered expired and cannot be used for certificate verification. |
 | timeStampingIntervalSeconds | integer        | 60                                       | Defines the interval of time-stamping service calls. Interval in seconds after which message log records must be timestamped. The interval must be between 60 and 86400 seconds. **Note: this value must be less than *ocspFreshnessSeconds.*** |
 
-## Global Configuration Generation Interval Parameter
+### 4.3 Global Configuration Generation Interval Parameter
 
-The global configuration generation interval parameter regulates the timing for global configuration generation. Global configuration generation is invoked by the Cron daemon[3]. The parameter is located at following file:
+The global configuration generation interval parameter regulates the timing for global configuration generation. Global configuration generation is invoked by the Cron daemon [[CRONMAN](#Ref_CRONMAN)]. The parameter is located at following file:
 
 	/etc/cron.d/xroad-center
 
-The file is deployed during X-Road installation and by default has following content[4]:
+The file is deployed during X-Road installation and by default has following content (see exact cron specifications) [[CRONHOW](#Ref_CRONHOW)]:
 
 	#!/bin/sh
 	* * * * * xroad curl http://127.0.0.1:8084/managementservice/gen_conf 2>1 >/dev/null;
 
 The parameter regulating the timing of global configuration generation is the cron expression at the start of the last line (\* \* \* \* \*), which means that global configuration generation is invoked every minute by default.
 
-# Configuration Proxy System Parameters
+## 5 Configuration Proxy System Parameters
 
 This chapter describes the system parameters used by the X-Road configuration proxy.
 
-### Configuration proxy module parameters: `[configuration-proxy]`
+### 5.1 Configuration proxy module parameters: `[configuration-proxy]`
 
 | **Name**                       | **Vanilla value**                       | **Description**    |
 |--------------------------------|-----------------------------------------|--------------------|
@@ -380,7 +387,7 @@ This chapter describes the system parameters used by the X-Road configuration pr
 | download-script                | /usr/share/xroad/scripts/download\_instance\_configuration.sh | Absolute path to the location of the script that initializes the global configuration download procedure. |
 | minimum-global-configuration-version | 2                                 | Minimum supported global configuration version on configuration proxy. Change this if old global configuration versions need to be supported. |
 
-### Signer parameters: `[signer]`
+### 5.2 Signer parameters: `[signer]`
 
 | **Name**                       | **Vanilla value**                       | **Description** |
 |--------------------------------|-----------------------------------------|-----------------|
@@ -388,9 +395,7 @@ This chapter describes the system parameters used by the X-Road configuration pr
 | ocsp-cache-path                | /var/cache/xroad                        | Absolute path to the directory where the cached OCSP responses are stored. |
 | enforce-token-pin-policy       | false                                   | Controls enforcing the token pin policy. When set to true, software token pin is required to be at least 10 ASCII characters from at least tree character classes (lowercase letters, uppercase letters, digits, special characters). (since version 6.7.7) |
 
-[1] See also [*http://www.quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger*](http://www.quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger).
-
-[2] Default value for proxy.client-tls-ciphers.
+[1] Default value for proxy.client-tls-ciphers.
 >TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
@@ -417,7 +422,3 @@ In Finnish package overridden to:
 > (see [*https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider*](https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider) for possible values)
 >
 > Note. OpenJDK 8 on RHEL 7 does not support ECDHE key agreement protocol, only DHE cipher suites are supported.
-
-[3] See also [*http://linux.die.net/man/8/cron*](http://linux.die.net/man/8/cron).
-
-[4] For exact format specification see also [*https://help.ubuntu.com/community/CronHowto*](https://help.ubuntu.com/community/CronHowto).

--- a/doc/OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md
+++ b/doc/OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md
@@ -4,7 +4,7 @@
 
 # X-Road: Operational Monitoring Daemon Architecture
 
-Version: 0.6  
+Version: 0.8  
 Document ID: ARC-OPMOND
 
 | Date       | Version     | Description                                                                  | Author             |
@@ -12,6 +12,7 @@ Document ID: ARC-OPMOND
 |  | 0.5       | Initial version               |          |
 | 23.01.2017 | 0.6       | Added license text, table of contents and version history | Sami Kallio |
 | 02.02.2018 | 0.7       | Technology matrix moved to the ARC-TEC-file               | Antti Luoma |
+| 05.03.2018 | 0.8       | Added terms and abbreviations reference and moved terms to term doc | Tatu Repo   |
 
 ## Table of Contents
 
@@ -61,12 +62,7 @@ The monitoring daemon also depends on central server that provides the global co
 
 ### 1.2 Terms and Abbrevations
 
-HTTP -- Hypertext Transfer Protocol  
-HTTPS -- Hypertext Transfer Protocol Secure  
-JMXMP -- Java Management Extensions Messaging Protocol  
-JSON -- JavaScript Object Notation  
-SOAP -- Simple Object Access Protocol  
-TLS -- Transport Layer security  
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
@@ -76,7 +72,8 @@ TLS -- Transport Layer security
 <a name="PR-OPMON"></a>**PR-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Protocol. Document ID: [PR-OPMON](../Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md).   
 <a name="PR-OPMONJMX"></a>**PR-OPMONJMX** -- Cybernetica AS. X-Road: Operational Monitoring JMX Protocol. Document ID: [PR-OPMONJMX](../Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).  
 <a name="PSQL"></a>**PSQL** -- PostgreSQL, https://www.postgresql.org/  
-<a name="ARC-TEC"></a>**ARC-TEC** -- X-Road technologies. Document ID: [ARC-TEC](../../Architecture/arc-tec_x-road_technologies.md).
+<a name="ARC-TEC"></a>**ARC-TEC** -- X-Road technologies. Document ID: [ARC-TEC](../../Architecture/arc-tec_x-road_technologies.md).  
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 
 ## 2 Component View

--- a/doc/OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md
+++ b/doc/OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md
@@ -66,14 +66,14 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
-<a name="ARC-G"></a>**ARC-G** -- Cybernetica AS. X-Road Architecture. Document ID: [ARC-G](../../Architecture/arc-g_x-road_arhitecture_1.4_Y-879-3.docx).  
+<a name="ARC-G"></a>**ARC-G** -- Cybernetica AS. X-Road Architecture. Document ID: [ARC-G](../../Architecture/arc-g_x-road_arhitecture.md).  
 <a name="PR-GCONF"></a>**PR-GCONF** -- Cybernetica AS. X-Road: Protocol for Downloading Configuration. Document ID: [PR-GCONF](../../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md).  
-<a name="PR-MESS"></a>**PR-MESS** -- Cybernetica AS. X-Road: Message Transport Protocol v4.0. Document ID: [PR-MESS](../../Protocols/pr-mess_x-road_message_protocol_v4.0_4.0.17.md).  
+<a name="PR-MESS"></a>**PR-MESS** -- Cybernetica AS. X-Road: Message Transport Protocol v4.0. Document ID: [PR-MESS](../../Protocols/pr-mess_x-road_message_protocol.md).  
 <a name="PR-OPMON"></a>**PR-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Protocol. Document ID: [PR-OPMON](../Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md).   
 <a name="PR-OPMONJMX"></a>**PR-OPMONJMX** -- Cybernetica AS. X-Road: Operational Monitoring JMX Protocol. Document ID: [PR-OPMONJMX](../Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).  
 <a name="PSQL"></a>**PSQL** -- PostgreSQL, https://www.postgresql.org/  
 <a name="ARC-TEC"></a>**ARC-TEC** -- X-Road technologies. Document ID: [ARC-TEC](../../Architecture/arc-tec_x-road_technologies.md).  
-<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
 
 
 ## 2 Component View

--- a/doc/OperationalMonitoring/Manuals/ug-opmonsyspar_x-road_operational_monitoring_system_parameters_Y-1099-1.md
+++ b/doc/OperationalMonitoring/Manuals/ug-opmonsyspar_x-road_operational_monitoring_system_parameters_Y-1099-1.md
@@ -35,7 +35,7 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 ## 1 Introduction
 
-This document describes the system parameters of the X-Road operational monitoring system components – the operational monitoring daemon, the operational monitoring buffer and the operational monitoring service. Changing the default values of the system parameters is explained in ([[UG-SYSPAR]](#UG-SYSPAR)).
+This document describes the system parameters of the X-Road operational monitoring system components – the operational monitoring daemon, the operational monitoring buffer and the operational monitoring service. Changing the default values of the system parameters is explained in \[[UG-SYSPAR](#UG-SYSPAR)\].
 
 ### 1.1 Terms and abbreviations
 
@@ -44,13 +44,13 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 ### 1.2 References
 
 <a name="UG-SYSPAR"></a>**UG-SYSPAR** -- Cybernetica AS. X-Road: System Parameters. Document ID: [UG-SYSPAR](../../Manuals/ug-syspar_x-road_v6_system_parameters.md).  
-<a name="UG-SS"></a>**UG-SS** -- Cybernetica AS. X-Road: Security Server User Guide. Document ID: [UG-SS](../../Manuals/ug-ss_x-road_6_security_server_user_guide_2.14_Y-883-32.docx).  
+<a name="UG-SS"></a>**UG-SS** -- Cybernetica AS. X-Road: Security Server User Guide. Document ID: [UG-SS](../../Manuals/ug-ss_x-road_6_security_server_user_guide.md).  
 <a name="CRON"></a>**CRON** -- Quartz Scheduler Cron Trigger Tutorial,  http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/crontrigger.html  
-<a id="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
 
 ## 2 Operational Monitoring System Parameters
 
-This chapter describes the system parameters used by the X-Road operational monitoring system. Changing the parameter values in the configuration file requires restarting of the system services. Managing the system services is explained in ([[UG-SS]](#UG-SS)).
+This chapter describes the system parameters used by the X-Road operational monitoring system. Changing the parameter values in the configuration file requires restarting of the system services. Managing the system services is explained in \[[UG-SS](#UG-SS)\].
 
 * To change the parameter values for the server component *op-monitor*, the service *xroad-opmonitor* must be restarted after changing all parameters except *op-monitor.tls-certificate*.
 * The service *xroad-proxy* must be restarted after changing the parameters:  
@@ -64,7 +64,7 @@ This chapter describes the system parameters used by the X-Road operational moni
 
 Server Component  | Parameter                 | Default Value        | Explanation
 ----------------- | ------------------------- | -------------------- | ------------------
-op-monitor        | clean-interval            | 0 0 0/12 1/1 \* ? \* | CRON expression ([[CRON]](#CRON)) defining the interval of deleting any operational data records that are older than *op-monitor.keep-records-for-days* from the operational monitoring database.
+op-monitor        | clean-interval            | 0 0 0/12 1/1 \* ? \* | CRON expression \[[CRON](#CRON)\] defining the interval of deleting any operational data records that are older than *op-monitor.keep-records-for-days* from the operational monitoring database.
 op-monitor        | client-tls-certificate    | /etc/xroad/ssl/internal.crt | Absolute filename of the TLS certificate (security server internal certificate) used by the HTTP client sending requests to the operational monitoring daemon. Configured in monitoring daemon server in case an external monitoring daemon is used.
 op-monitor        | health-statistics-period-seconds | 600           | The period for gathering health statistics about services in seconds.
 op-monitor        | host                      | localhost            | The host address on which the operational monitoring daemon listens.

--- a/doc/OperationalMonitoring/Manuals/ug-opmonsyspar_x-road_operational_monitoring_system_parameters_Y-1099-1.md
+++ b/doc/OperationalMonitoring/Manuals/ug-opmonsyspar_x-road_operational_monitoring_system_parameters_Y-1099-1.md
@@ -6,7 +6,7 @@
 
 # User Guide
 
-Version: 0.4  
+Version: 0.5  
 Doc ID: UG-OPMONSYSPAR
 
 | Date       | Version | Description                                                                  | Author             |
@@ -14,6 +14,7 @@ Doc ID: UG-OPMONSYSPAR
 |            | 0.2     | Initial version                                                              |                    |
 | 23.01.2017 | 0.3     | Added license text, table of contents and version history                    | Sami Kallio        |
 | 17.03.2017 | 0.4     | Added new parameters *op-monitor-buffer.connection-timeout-seconds* and *op-monitor-service.connection-timeout-seconds* | Kristo Heero       |
+| 05.03.2018 | 0.5     | Added reference to terms and abbreviations doc | Tatu Repo | 
 
 ## Table of Contents
 
@@ -21,7 +22,8 @@ Doc ID: UG-OPMONSYSPAR
 
 - [License](#license)
 - [1 Introduction](#1-introduction)
-  * [1.1 References](#11-references)
+  * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+  * [1.2 References](#12-references)
 - [2 Operational Monitoring System Parameters](#2-operational-monitoring-system-parameters)
 
 <!-- tocstop -->
@@ -35,11 +37,16 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 This document describes the system parameters of the X-Road operational monitoring system components – the operational monitoring daemon, the operational monitoring buffer and the operational monitoring service. Changing the default values of the system parameters is explained in ([[UG-SYSPAR]](#UG-SYSPAR)).
 
-### 1.1 References
+### 1.1 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+### 1.2 References
 
 <a name="UG-SYSPAR"></a>**UG-SYSPAR** -- Cybernetica AS. X-Road: System Parameters. Document ID: [UG-SYSPAR](../../Manuals/ug-syspar_x-road_v6_system_parameters.md).  
 <a name="UG-SS"></a>**UG-SS** -- Cybernetica AS. X-Road: Security Server User Guide. Document ID: [UG-SS](../../Manuals/ug-ss_x-road_6_security_server_user_guide_2.14_Y-883-32.docx).  
-<a name="CRON"></a>**CRON** -- Quartz Scheduler Cron Trigger Tutorial,  http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/crontrigger.html
+<a name="CRON"></a>**CRON** -- Quartz Scheduler Cron Trigger Tutorial,  http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/crontrigger.html  
+<a id="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Operational Monitoring System Parameters
 

--- a/doc/OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md
@@ -6,20 +6,22 @@
 
 **Technical Specification**
 
-Version: 0.3  
+Version: 0.4  
 Doc. ID: PR-OPMON
 
 | Date       | Version     | Description                                                                  | Author             |
 |------------|-------------|------------------------------------------------------------------------------|--------------------|
 |  | 0.2       | Initial version               |          |
 | 23.01.2017 | 0.3       | Added license text, table of contents and version history | Sami Kallio |
+| 05.03.2018 | 0.4       | Added terms and abbreviations reference
 
 ## Table of Contents
 
 <!-- toc -->
 
 - [1 Introduction](#1-introduction)
-    + [1.1 References](#11-references)
+    + [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+    + [1.2 References](#12-references)
 - [2 Retrieving Operational Data of Security Server](#2-retrieving-operational-data-of-security-server)
 - [3 Retrieving Health Data of Security Server](#3-retrieving-health-data-of-security-server)
 - [Annex A WSDL for Operational Monitoring Messages](#annex-a-wsdl-for-operational-monitoring-messages)
@@ -57,13 +59,18 @@ This specification does not include option for partially implementing the protoc
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document (in uppercase, as shown) are to be interpreted as described in [[RFC2119]](#RFC2119).
 
-### 1.1 References
+### 1.1 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
+
+### 1.2 References
 
 <a name="PR-MESS"></a>**PR-MESS** -- Cybernetica AS. X-Road: Message Transport Protocol v4.0. Document ID: [PR-MESS](../../Protocols/pr-mess_x-road_message_protocol_v4.0_4.0.17.md).  
 <a name="WSDL"></a>**WSDL** -- Web Services Description Language (WSDL) 1.1. World Wide Web Consortium. 15 March 2001, https://www.w3.org/TR/2001/NOTE-wsdl-20010315  
 <a name="SWAREF"></a>**SWAREF** -- Attachments Profile Version 1.0, http://www.ws-i.org/Profiles/AttachmentsProfile-1.0-2004-08-24.html  
 <a name="RFC1952"></a>**RFC1952** -- GZIP file format specification version 4.3, https://tools.ietf.org/html/rfc1952  
-<a name="RFC2119"></a>**RFC2119** -- Key words for use in RFCs to Indicate Requirement Levels. Request for Comments 2119, Internet Engineering Task Force, March 1997, https://www.ietf.org/rfc/rfc2119.txt
+<a name="RFC2119"></a>**RFC2119** -- Key words for use in RFCs to Indicate Requirement Levels. Request for Comments 2119, Internet Engineering Task Force, March 1997, https://www.ietf.org/rfc/rfc2119.txt  
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 # 2 Retrieving Operational Data of Security Server
 

--- a/doc/OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md
@@ -13,7 +13,7 @@ Doc. ID: PR-OPMON
 |------------|-------------|------------------------------------------------------------------------------|--------------------|
 |  | 0.2       | Initial version               |          |
 | 23.01.2017 | 0.3       | Added license text, table of contents and version history | Sami Kallio |
-| 05.03.2018 | 0.4       | Added terms and abbreviations reference
+| 05.03.2018 | 0.4       | Added terms and abbreviations reference | Tatu Repo
 
 ## Table of Contents
 
@@ -47,17 +47,17 @@ The operational monitoring services are the following:
 * *getSecurityServerOperationalData* - downloading operational data of the specified time period of the security server.
 * *getSecurityServerHealthData* - downloading health data of the security server.
 
-The operational monitoring services are implemented as standard X-Road services (see [[PR-MESS]](#PR-MESS) for detailed description of the protocol) that are offered by the owner of the security servers.
+The operational monitoring services are implemented as standard X-Road services (see \[[PR-MESS](#PR-MESS)\] for detailed description of the protocol) that are offered by the owner of the security servers.
 
 This protocol builds on existing transport and message encoding mechanisms. Therefore, this specification does not cover the technical details and error conditions related to making HTTP(S) requests together with processing MIME-encoded messages. These concerns are discussed in detail in their respective standards.
 
-The low-level technical details of the operational monitoring services are specified using the WSDL [[WSDL]](#WSDL) syntax. See [[Annex A]](#AnnexA) for operational monitoring services WSDL file.
+The low-level technical details of the operational monitoring services are specified using the WSDL \[[WSDL](#WSDL)\] syntax. See \[[Annex A](#AnnexA)\] for operational monitoring services WSDL file.
 
-Chapters 2 and 3 together with annexes [[Annex A]](#AnnexA) and [[Annex B]](AnnexB) contain normative information. All the other sections are informative in nature. All the references are normative.
+Chapters 2 and 3 together with annexes \[[Annex A](#AnnexA)\] and \[[Annex B](AnnexB)\] contain normative information. All the other sections are informative in nature. All the references are normative.
 
 This specification does not include option for partially implementing the protocol – the conformant implementation must implement the entire specification.
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document (in uppercase, as shown) are to be interpreted as described in [[RFC2119]](#RFC2119).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document (in uppercase, as shown) are to be interpreted as described in \[[RFC2119](#RFC2119)\].
 
 ### 1.1 Terms and abbreviations
 
@@ -65,12 +65,12 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 
-<a name="PR-MESS"></a>**PR-MESS** -- Cybernetica AS. X-Road: Message Transport Protocol v4.0. Document ID: [PR-MESS](../../Protocols/pr-mess_x-road_message_protocol_v4.0_4.0.17.md).  
+<a name="PR-MESS"></a>**PR-MESS** -- Cybernetica AS. X-Road: Message Transport Protocol v4.0. Document ID: [PR-MESS](../../Protocols/pr-mess_x-road_message_protocol.md).  
 <a name="WSDL"></a>**WSDL** -- Web Services Description Language (WSDL) 1.1. World Wide Web Consortium. 15 March 2001, https://www.w3.org/TR/2001/NOTE-wsdl-20010315  
 <a name="SWAREF"></a>**SWAREF** -- Attachments Profile Version 1.0, http://www.ws-i.org/Profiles/AttachmentsProfile-1.0-2004-08-24.html  
 <a name="RFC1952"></a>**RFC1952** -- GZIP file format specification version 4.3, https://tools.ietf.org/html/rfc1952  
 <a name="RFC2119"></a>**RFC2119** -- Key words for use in RFCs to Indicate Requirement Levels. Request for Comments 2119, Internet Engineering Task Force, March 1997, https://www.ietf.org/rfc/rfc2119.txt  
-<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
 
 # 2 Retrieving Operational Data of Security Server
 
@@ -120,7 +120,7 @@ The body of the request MUST contain an XML element *getSecurityServerOperationa
  * *soapFaultCode*
  * *soapFaultString*
 
-The fields are described in the JSON-schema of the response payload [[Annex B]](#AnnexB).
+The fields are described in the JSON-schema of the response payload \[[Annex B](#AnnexB)\].
 
 The XML schema fragment of the operational data request body is shown below. For clarity, documentation in the schema fragment is omitted.
 
@@ -146,9 +146,9 @@ The XML schema fragment of the operational data request body is shown below. For
 </xs:complexType>
 ```
 
-The example request message is presented in [[Annex C.1]](#AnnexC.1).
+The example request message is presented in \[[Annex C.1](#AnnexC.1)\].
 
-The response MUST be MIME multipart message with attachment using swaRef [[SWAREF]](#SWAREF). The response MUST contain the following MIME parts.
+The response MUST be MIME multipart message with attachment using swaRef \[[SWAREF](#SWAREF)\]. The response MUST contain the following MIME parts.
 
 1. X-Road SOAP response message. The message MUST contain the regular X-Road headers and the body MUST contain the following elements.
  * *recordsCount* (mandatory) -- Number of records in the payload.
@@ -157,7 +157,7 @@ The response MUST be MIME multipart message with attachment using swaRef [[SWARE
 
  The content type of this part MUST be *text/xml*.
 
-2. Operational data (payload). This MIME part MUST contain queried operational data records in JSON format and compressed (GZIP [[RFC1952]](#RFC1952)) . The content type of this part MUST be *application/gzip*. The JSON-Schema for payload is described in [[Annex B]](#AnnexB).
+2. Operational data (payload). This MIME part MUST contain queried operational data records in JSON format and compressed (GZIP \[[RFC1952](#RFC1952)\]) . The content type of this part MUST be *application/gzip*. The JSON-Schema for payload is described in \[[Annex B](#AnnexB)\].
 
 The XML schema fragment of the operational data response body is shown below. For clarity, documentation in the schema fragment is omitted.
 
@@ -171,7 +171,7 @@ The XML schema fragment of the operational data response body is shown below. Fo
 </xs:complexType>
 ```
 
-The example response message is presented in [[Annex C.2]](#AnnexC.2).
+The example response message is presented in \[[Annex C.2](#AnnexC.2)\].
 
 # 3 Retrieving Health Data of Security Server
 
@@ -197,7 +197,7 @@ The XML schema fragment of the health data request body is shown below. For clar
 </xs:complexType>    
 ```
 
-The example request message is presented in [[Annex C.3]](#AnnexC.3).
+The example request message is presented in \[[Annex C.3](#AnnexC.3)\].
 
 The response message MUST contain health data of the queried security server:
  * *monitoringStartupTimestamp* -- The Unix timestamp in milliseconds when the monitoring system was started.
@@ -270,7 +270,7 @@ The XML schema fragment of the health data response body is shown below. For cla
 </xs:complexType>
 ```
 
-The example response message is presented in [[Annex C.4]](#AnnexC.4).
+The example response message is presented in \[[Annex C.4](#AnnexC.4)\].
 
 <a name="AnnexA"/></a>
 # Annex A WSDL for Operational Monitoring Messages

--- a/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
@@ -39,11 +39,11 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 This document specifies the format and protocol for exchanging health data of X-Road security servers that the X-Road operational monitoring daemon makes available for applications implementing the Java Management Extensions (JMX) using the JMX Messaging Protocol (JMXMP).
 
-The Java Management Extensions define and architecture, the design patterns, the APIs, and the services for application and network management and monitoring in the Java programming language [[JMX]](#Ref_JMX).
+The Java Management Extensions define and architecture, the design patterns, the APIs, and the services for application and network management and monitoring in the Java programming language \[[JMX](#Ref_JMX)\].
 
-The JMX Messaging Protocol (JMXMP) connector is a configuration of the generic connector where the transport protocol is based on TCP and the object wrapping is native Java serialization [[JMXMP]](#Ref_JMXMP).
+The JMX Messaging Protocol (JMXMP) connector is a configuration of the generic connector where the transport protocol is based on TCP and the object wrapping is native Java serialization \[[JMXMP](#Ref_JMXMP)\].
 
-In this document, the standard Managed Beans (`MBeans`) exposed by the operational monitoring daemon, their attributes, value types etc, are documented. The underlying protocol, error handling, authentication and encryption used in data exchange over JMXMP, are not in the scope of this document. For such details, [[JMX]](#Ref_JMX) and [[JMXMP]](#Ref_JMXMP) should be consulted.
+In this document, the standard Managed Beans (`MBeans`) exposed by the operational monitoring daemon, their attributes, value types etc, are documented. The underlying protocol, error handling, authentication and encryption used in data exchange over JMXMP, are not in the scope of this document. For such details, \[[JMX](#Ref_JMX)\] and \[[JMXMP](#Ref_JMXMP)\] should be consulted.
 
 All the sections of this specification contain normative information. All the references are normative.
 
@@ -55,27 +55,27 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 
-<a name="Ref_PR-MESS"></a>**PR-MESS** -- Cybernetica AS. X-Road: Message Protocol v4.0. Document ID: [PR-MESS](../../Protocols/pr-mess_x-road_message_protocol_v4.0_4.0.17.md)  
+<a name="Ref_PR-MESS"></a>**PR-MESS** -- Cybernetica AS. X-Road: Message Protocol v4.0. Document ID: [PR-MESS](../../Protocols/pr-mess_x-road_message_protocol.md).  
 <a name="Ref_JMX"></a>**JMX** -- Java Management Extensions (JMX) Specification, version 1.4, http://download.oracle.com/otn-pub/jcp/jmx_remote-1_4-mrel2-eval-spec/jsr160-jmx-1_4-mrel4-spec-FINAL-v1_0.pdf  
 <a name="Ref_JMXMP"></a>**JMXMP** -- Using JMX Connectors to Manage Resources Remotely, http://docs.oracle.com/javase/8/docs/technotes/guides/jmx/overview/connectors.html  
 <a name="Ref_METRICS"></a>**METRICS** -- GitHub - dropwizard/metrics: Capturing JVM- and application-level metrics. So you know what's going on, https://github.com/dropwizard/metrics  
 <a name="Ref_ZABBIX"></a>**ZABBIX** -- Zabbix Documentation 3.0 - JMX monitoring, https://www.zabbix.com/documentation/3.0/manual/config/items/itemtypes/jmx_monitoring  
-<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
 
 <a name="section_2"></a>
 # 2 Encoding X-Road Service Identifiers in Object Names
 
 In the object names of exposed MBeans, X-Road service identifiers are encoded according to the following rules:
 
-* The full string form of the identifier of the service is used, as defined in [[PR-MESS]]("Ref_PR-MESS").
+* The full string form of the identifier of the service is used, as defined in \[[PR-MESS](#Ref_PR-MESS)\].
 * If no subsystem is associated with the service, two forward slashes (`//`) are used in succession, for example: `EE/GOV/00000001//getSecurityServerOperationalData`. This is to enable extraction of the parts of the identifier from the string form.
 * Also for being able to extract the parts of the identifier, the forward slashes that are found in the parts of the identifiers, are escaped with the escape sequence `&#47;`.
 * Because the JMXMP protocol imposes the XML character set on the names of objects, the following characters are escaped using XML escape sequences: `"` (`&quot;`), `'` (`&apos;`), `<` (`&lt;`), `>` (`&gt;`), `&` (`&amp;`).
-* In order to provide compatibility with the Zabbix monitoring system [[ZABBIX]]("Ref_ZABBIX"), the following characters are escaped in addition: `.` (`&#46;`), `\` (`&#92;`), the space (`&#32;`), `,` (`&#44;`), `[` (`&#91;`), `]` (`&#93;`).
+* In order to provide compatibility with the Zabbix monitoring system \[[ZABBIX](#Ref_ZABBIX)\], the following characters are escaped in addition: `.` (`&#46;`), `\` (`&#92;`), the space (`&#32;`), `,` (`&#44;`), `[` (`&#91;`), `]` (`&#93;`).
 
 # 3 Objects, Attributes and Operations Exposed over JMXMP
 
-The `MBean` objects exposed by the operational monitoring daemon over JMXMP have been implemented using the types of metrics available in the `com.codahale.metrics` library [[METRICS]](#Ref_METRICS), version 3.0. All the metric classes implement the `com.codahale.metrics.Metric` interface. More precisely, the following classes are used for making health data available:
+The `MBean` objects exposed by the operational monitoring daemon over JMXMP have been implemented using the types of metrics available in the `com.codahale.metrics` library \[[METRICS](#Ref_METRICS)\], version 3.0. All the metric classes implement the `com.codahale.metrics.Metric` interface. More precisely, the following classes are used for making health data available:
 
 * `com.codahale.metrics.Gauge`  
 * `com.codahale.metrics.Counter`  
@@ -97,7 +97,7 @@ For each service mediated during the configured statistics period, the following
 * `metrics:name=lastSuccessfulRequestTimestamp(<service ID>)`    
 * `metrics:name=lastUnsuccessfulRequestTimestamp(<service ID>)`  
 
-where `<service ID>` will be replaced by the full ID of the service encoded as described in [[Section 2]](#section_2).
+where `<service ID>` will be replaced by the full ID of the service encoded as described in \[[Section 2](#section_2)\].
 
 # 3.2 Counter Metrics
 
@@ -109,7 +109,7 @@ For each service mediated during the configured statistics period, the following
 * `metrics:name=successfulRequestCount(<service ID>)`  
 * `metrics:name=unsuccessfulRequestCount(<service ID>)`  
 
-where `<service ID>` will be replaced by the full ID of the service encoded as described in [[Section 2]](#section_2).
+where `<service ID>` will be replaced by the full ID of the service encoded as described in \[[Section 2](#section_2)\.
 
 # 3.3 Histogram Metrics
 
@@ -136,4 +136,4 @@ For each service mediated during the configured statistics period, the following
 * `metrics:name=requestSoapSize(<service ID>)`  
 * `metrics:name=responseSoapSize(<service ID>)`  
 
-where `<service ID>` will be replaced by the full ID of the service encoded as described in [[Section 2]](#section_2).
+where `<service ID>` will be replaced by the full ID of the service encoded as described in \[[Section 2](#section_2)\].

--- a/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
@@ -6,13 +6,14 @@
 
 **Technical Specification**
 
-Version: 0.3  
+Version: 0.4  
 Doc. ID: PR-OPMONJMX
 
 | Date       | Version     | Description                                                                  | Author             |
 |------------|-------------|------------------------------------------------------------------------------|--------------------|
 |  | 0.2       | Initial version               |          |
 | 23.01.2017 | 0.3       | Added license text, table of contents and version history | Sami Kallio |
+| 05.03.2018 | 0.4       | Added terms and abbreviations reference and moved terms to term doc | Tatu Repo |
 
 ## Table of Contents
 
@@ -50,9 +51,7 @@ This specification does not include option for partially implementing the protoc
 
 ### 1.1 Terms and Abbreviations
 
-JMX -- The Java Management Extensions  
-JMXMP -- The JMX Messaging Protocol  
-MBean -- Java Managed Bean  
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 
@@ -60,7 +59,8 @@ MBean -- Java Managed Bean
 <a name="Ref_JMX"></a>**JMX** -- Java Management Extensions (JMX) Specification, version 1.4, http://download.oracle.com/otn-pub/jcp/jmx_remote-1_4-mrel2-eval-spec/jsr160-jmx-1_4-mrel4-spec-FINAL-v1_0.pdf  
 <a name="Ref_JMXMP"></a>**JMXMP** -- Using JMX Connectors to Manage Resources Remotely, http://docs.oracle.com/javase/8/docs/technotes/guides/jmx/overview/connectors.html  
 <a name="Ref_METRICS"></a>**METRICS** -- GitHub - dropwizard/metrics: Capturing JVM- and application-level metrics. So you know what's going on, https://github.com/dropwizard/metrics  
-<a name="Ref_ZABBIX"></a>**ZABBIX** -- Zabbix Documentation 3.0 - JMX monitoring, https://www.zabbix.com/documentation/3.0/manual/config/items/itemtypes/jmx_monitoring
+<a name="Ref_ZABBIX"></a>**ZABBIX** -- Zabbix Documentation 3.0 - JMX monitoring, https://www.zabbix.com/documentation/3.0/manual/config/items/itemtypes/jmx_monitoring  
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 <a name="section_2"></a>
 # 2 Encoding X-Road Service Identifiers in Object Names

--- a/doc/OperationalMonitoring/Testing/test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md
+++ b/doc/OperationalMonitoring/Testing/test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md
@@ -54,7 +54,7 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 ### 1.1 Purpose
 
-The purpose of this document is to describe the levels and procedures of testing used during the development of the operational monitoring components of the X-Road system. While the testing strategy of the development project ([[TEST-OPMONSTRAT]](#TEST-OPMONSTRAT)) describes the overall approach to testing, this plan offers a more technical and detailed view of the testing levels, the tools used and the functionality covered by testing.
+The purpose of this document is to describe the levels and procedures of testing used during the development of the operational monitoring components of the X-Road system. While the testing strategy of the development project (\[[TEST-OPMONSTRAT](#TEST-OPMONSTRAT)\]) describes the overall approach to testing, this plan offers a more technical and detailed view of the testing levels, the tools used and the functionality covered by testing.
 
 ### 1.2 Terms and Abbreviations
 
@@ -66,15 +66,15 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 <a name="ARC-OPMOND"></a>**ARC-OPMOND** -- Cybernetica AS. X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md).  
 <a name="TEST-OPMONSTRAT"></a>**TEST-OPMONSTRAT** -- Cybernetica AS. X-Road: Operational Monitoring Testing Strategy. Document ID: [TEST-OPMONSTRAT](test-opmonstrat_x-road_operational_monitoring_testing_strategy_Y-1104-1.md)  
 <a name="UC-OPMON"></a>**UC-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Daemon Use Case Model. Document ID: [UC-OPMON](../UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md).  
-<a name="UG-SS"></a>**UG-SS** -- Cybernetica AS. X-Road: Security Server User Guide. Document ID: [UG-SS](../../Manuals/ug-ss_x-road_6_security_server_user_guide_2.14_Y-883-32.docx).  
+<a name="UG-SS"></a>**UG-SS** -- Cybernetica AS. X-Road: Security Server User Guide. Document ID: [UG-SS](../../Manuals/ug-ss_x-road_6_security_server_user_guide.md).  
 <a name="PR-OPMONJMX"></a>**PR-OPMONJMX** -- Cybernetica AS. Operational Monitoring Daemon JMXMP Interface. Document ID: [PR-OPMONJMX](../Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).  
-<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
 
 ## 2 Components of the Operational Monitoring System in the Context of Testing
 
 The operational monitoring system involves the X-Road security server and the operational monitoring daemon. In addition, global configuration is obtained from the X-Road central server.
 
-According to the architecture of the operational monitoring daemon ([[ARC-OPMOND]](#ARC-OPMOND)), the daemon is divided into the following components:
+According to the architecture of the operational monitoring daemon (\[[ARC-OPMOND](#ARC-OPMOND)\]), the daemon is divided into the following components:
 * operational monitoring database
 * operational monitoring service
 
@@ -84,7 +84,7 @@ In this project, testing will mainly focus on the behaviour of the operational m
 
 ### 2.1 Testing the Operational Monitoring Database
 
-The operational monitoring database component collects operational data of the X-Road security server(s) via the Store Operational Data interface. The requirements for data stored in the database are defined in [[HD_1]](#HD_1).
+The operational monitoring database component collects operational data of the X-Road security server(s) via the Store Operational Data interface. The requirements for data stored in the database are defined in \[[HD_1](#HD_1)\].
 
 The database is tested at the following levels:
 * Direct SQL is used by the developers and testers for ad-hoc queries during development and testing. The source code of the operational monitoring daemon does not make any raw SQL queries, however.
@@ -114,14 +114,14 @@ The JMXMP interface is tested manually.
 
 ## 4 The Use Cases of the Operational Monitoring Daemon in the Context of Testing
 
-The use cases defined in [[UC-OPMON]](#UC-OPMON) are directly or indirectly covered by the automated integration tests. In particular:
+The use cases defined in \[[UC-OPMON](#UC-OPMON)\] are directly or indirectly covered by the automated integration tests. In particular:
 * UC OPMON_01: Storing operational data (and updating the in-memory health data) is carried out in all the automated test cases, unless the test checks that operational data is *not* written.
-* UC OPMON_02: Querying operational data is carried out in all the automated test cases except for [[test_health_data]](#test_health_data) which only queries health data.
-* UC OPMON_03: Health data of the security server is queried in the automated test case [[test_health_data]](#test_health_data).
+* UC OPMON_02: Querying operational data is carried out in all the automated test cases except for \[[test_health_data](#test_health_data)\] which only queries health data.
+* UC OPMON_03: Health data of the security server is queried in the automated test case \[[test_health_data](#test_health_data)\].
 
 ## 5 Automated Integration Testing in Detail
 
-Automated integration tests are carried out on a pre-configured testing system with the required X-Road components installed and configured, as described in [[TEST-OPMONSTRAT]](#TEST-OPMONSTRAT). It is assumed that during integration testing, no manual testing is carried out on the same systems. Otherwise, arbitrary X-Road message exchange would interfere with the tests and cause false negative results.
+Automated integration tests are carried out on a pre-configured testing system with the required X-Road components installed and configured, as described in \[[TEST-OPMONSTRAT](#TEST-OPMONSTRAT)\]. It is assumed that during integration testing, no manual testing is carried out on the same systems. Otherwise, arbitrary X-Road message exchange would interfere with the tests and cause false negative results.
 
 The testcases are listed in alphabetical order. They can be run in an arbitrary order and do not depend on the results of each other.
 
@@ -162,7 +162,7 @@ During general load testing of the operational monitoring system, it was observe
 
 ### 6.2 Setup of the Simulations
 
-Load simulations can be run automatically, provided the testing environment has been set up as described in [[TEST-OPMONSTRAT]](#TEST-OPMONSTRAT). The reports of the simulation should be analyzed for information about the behaviour of the system under the simulated load.
+Load simulations can be run automatically, provided the testing environment has been set up as described in \[[TEST-OPMONSTRAT](#TEST-OPMONSTRAT)\]. The reports of the simulation should be analyzed for information about the behaviour of the system under the simulated load.
 
 The load test runner and the related source code can be found in the source repository of the project at `src/systemtest/op-monitoring/load`.
 
@@ -192,7 +192,7 @@ In order to measure the effect on the round-trip times of X-Road requests by the
 1. The operational monitoring buffer has been disabled by specifying *op-monitor-buffer.size=0* in the configuration of the security server under test (and the xroad-proxy service restarted).
 2. The operational monitoring buffer has been enabled by removing the parameter *op-monitor-buffer.size* from the configuration of the security server under test (and the xroad-proxy service restarted).
 
-Please refer to [[UG-SS]](#UG-SS) for instructions on configuring and restarting the components of the security server.
+Please refer to \[[UG-SS](#UG-SS)\] for instructions on configuring and restarting the components of the security server.
 
 Under both setups, the desired load simulation must be be run at least 3 times, assuming there are no other sources of load on the system under test during the simulations. In the output of the simulations, the request statistics will be observed, comparing the results for both setups. Because the initial handshake of the TLS session between security servers affects the round-trip time of the first request in the simulation by the order of a second, the mean response time is not a reliable value. Rather the "response time 50th percentile" value will give a good average estimate of response times.
 
@@ -241,7 +241,7 @@ In the environment under test, enabling the operational monitoring buffer added 
 
 ## 7 Testing the JMXMP Interface
 
-The JMXMP interface gets the data it exposes from the same component that is used to serve health data over the Operational Monitoring Query interface. Thus, the internal implementation of the health metrics registry is tested in the automated test case [test_health_data](#test_health_data). The main difference when directly using the JMXMP interface is in the format that the items are presented. The data exposed over JMXMP and their format are described in detail in [[PR-OPMONJMX]](#PR-OPMONJMX).
+The JMXMP interface gets the data it exposes from the same component that is used to serve health data over the Operational Monitoring Query interface. Thus, the internal implementation of the health metrics registry is tested in the automated test case [test_health_data](#test_health_data). The main difference when directly using the JMXMP interface is in the format that the items are presented. The data exposed over JMXMP and their format are described in detail in \[[PR-OPMONJMX](#PR-OPMONJMX)\].
 
 For quick reference, a couple of examples follow.
 
@@ -280,13 +280,13 @@ where `address` should be set to the desired listening address for access by `jc
 
 The health metrics of the operational monitoring daemon will appear on the `MBeans` tab, in the `metrics` subtree.
 
-The items appearing under this subtree can be observed as the automated integration tests are run. Please refer to [[PR-OPMONJMX]](#PR-OPMONJMX) for the exact set of items required for each mediated request. Note that a separate `jconsole` session should be opened for the producer and the consumer security servers, to gain access to all the metrics made available.
+The items appearing under this subtree can be observed as the automated integration tests are run. Please refer to \[[PR-OPMONJMX](#PR-OPMONJMX)\] for the exact set of items required for each mediated request. Note that a separate `jconsole` session should be opened for the producer and the consumer security servers, to gain access to all the metrics made available.
 
 **NOTE** Because the health metrics related to mediated services are reset upon each restart of the operational monitoring daemon, the necessary configuration of the system should be carried out before running each automated test case. Please refer to `src/systemtest/op-monitoring/integration/run_tests.py` (`LOCAL_INI_PARAMETERS` and each test case in `OperationalMonitoringIntegrationTest`) for information about the necessary configuration.
 
 ## 8 Manual Integration Testing in Detail
 
-This chapter contains the descriptions of manual test cases of the operational monitoring system. Manual test cases cover only the functionality that is not covered by automated integration tests. Manual integration tests are carried out on a pre-configured testing system with the required X-Road components installed and configured, as described in [[TEST-OPMONSTRAT]](#TEST-OPMONSTRAT).
+This chapter contains the descriptions of manual test cases of the operational monitoring system. Manual test cases cover only the functionality that is not covered by automated integration tests. Manual integration tests are carried out on a pre-configured testing system with the required X-Road components installed and configured, as described in \[[TEST-OPMONSTRAT](#TEST-OPMONSTRAT)\].
 
 ### 8.1 Test Helpers
 The test steps described here are to be executed when refered to in test cases.
@@ -403,11 +403,11 @@ All test steps are executed in security server *xtee9.ci.kit*.
 Test case for verifying that it is possible to configure a secure connection between the security server and the external operational monitoring daemon.
 
 **Preconditions:**
-* The tester has superuser access to a server corresponding to the minimum requirements for an external monitoring daemon (see [[UG-SS]](#UG-SS)) to be used for installing an external operational monitoring daemon.
+* The tester has superuser access to a server corresponding to the minimum requirements for an external monitoring daemon (see \[[UG-SS](#UG-SS)\]) to be used for installing an external operational monitoring daemon.
 
 **Test scenario:**
-* Install an external operational monitoring daemon according to the instructions in [[UG-SS]](#UG-SS).
-* Configure security server *xtee10.ci.kit* to use the external operational monitoring daemon installed in the previous step over a secure connection. Follow the instructions in [[UG-SS]](#UG-SS).
+* Install an external operational monitoring daemon according to the instructions in \[[UG-SS](#UG-SS)\].
+* Configure security server *xtee10.ci.kit* to use the external operational monitoring daemon installed in the previous step over a secure connection. Follow the instructions in \[[UG-SS](#UG-SS)\].
 * Send an X-Road request to a service provider in security server *xtee10.ci.kit*. The example request can be found in the source repository of the project at `src/systemtest/op-monitoring/requests/service_in_ss2.query` (the request endpoint is security server *xtee9.ci.kit*).
 * Log in to the operational monitoring database in the external monitoring daemon (see [logging in to operational monitoring database](#log_in_db)) and ascertain that the operational monitoring data of the request sent in the previous step has been saved in the database. SQL example:
   ```sql

--- a/doc/OperationalMonitoring/Testing/test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md
+++ b/doc/OperationalMonitoring/Testing/test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md
@@ -4,13 +4,14 @@
 
 # X-Road: Operational Monitoring Testing Plan
 
-Version: 0.6  
+Version: 0.7  
 Doc ID: TEST-OPMON
 
 | Date       | Version     | Description                                                                  | Author             |
 |------------|-------------|------------------------------------------------------------------------------|--------------------|
 |  | 0.5       | Initial version               |          |
 | 23.01.2017 | 0.6       | Added license text, table of contents and version history | Sami Kallio |
+| 05.03.2018 | 0.7       | Added terms and abbreviations reference and moved terms to term doc. | Tatu Repo |
 
 ## Table of Contents
 <!-- toc -->
@@ -57,14 +58,7 @@ The purpose of this document is to describe the levels and procedures of testing
 
 ### 1.2 Terms and Abbreviations
 
-HTTP -- Hypertext Transfer Protocol  
-HTTPS -- Hypertext Transfer Protocol Secure  
-JMXMP -- Java Management Extensions Messaging Protocol  
-JSON -- JavaScript Object Notation  
-SOAP -- Simple Object Access Protocol  
-DSL -- Domain Specific Language  
-SDK -- Software Development Kit  
-SSH -- Secure Shell
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
@@ -73,7 +67,8 @@ SSH -- Secure Shell
 <a name="TEST-OPMONSTRAT"></a>**TEST-OPMONSTRAT** -- Cybernetica AS. X-Road: Operational Monitoring Testing Strategy. Document ID: [TEST-OPMONSTRAT](test-opmonstrat_x-road_operational_monitoring_testing_strategy_Y-1104-1.md)  
 <a name="UC-OPMON"></a>**UC-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Daemon Use Case Model. Document ID: [UC-OPMON](../UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md).  
 <a name="UG-SS"></a>**UG-SS** -- Cybernetica AS. X-Road: Security Server User Guide. Document ID: [UG-SS](../../Manuals/ug-ss_x-road_6_security_server_user_guide_2.14_Y-883-32.docx).  
-<a name="PR-OPMONJMX"></a>**PR-OPMONJMX** -- Cybernetica AS. Operational Monitoring Daemon JMXMP Interface. Document ID: [PR-OPMONJMX](../Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).
+<a name="PR-OPMONJMX"></a>**PR-OPMONJMX** -- Cybernetica AS. Operational Monitoring Daemon JMXMP Interface. Document ID: [PR-OPMONJMX](../Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).  
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Components of the Operational Monitoring System in the Context of Testing
 

--- a/doc/OperationalMonitoring/Testing/test-opmonstrat_x-road_operational_monitoring_testing_strategy_Y-1104-1.md
+++ b/doc/OperationalMonitoring/Testing/test-opmonstrat_x-road_operational_monitoring_testing_strategy_Y-1104-1.md
@@ -4,13 +4,14 @@
 
 # X-Road: Operational Monitoring Testing Strategy
 
-Version: 0.6  
+Version: 0.7  
 Doc. ID: TEST-OPMONSTRAT
 
 | Date       | Version     | Description                                                                  | Author             |
 |------------|-------------|------------------------------------------------------------------------------|--------------------|
 |  | 0.5       | Initial version               |          |
 | 23.01.2017 | 0.6       | Added license text, table of contents and version history | Sami Kallio |
+| 05.03.2018 | 0.7       | Added terms and abbreviations reference and moved terms to term doc | Tatu Repo | 
 
 ## Table of Contents
 
@@ -55,14 +56,7 @@ A detailed testing plan will be delivered as a separate document in [[TEST-OPMON
 
 ### 1.2 Terms and Abbreviations
 
-HTTP -- Hypertext Transfer Protocol  
-HTTPS -- Hypertext Transfer Protocol Secure  
-JMXMP -- Java Management Extensions Messaging Protocol  
-SOAP -- Simple Object Access Protocol  
-DSL -- Domain Specific Language  
-CA -- Certification Authority  
-TSA -- Timestamping Authority  
-CI -- Continuous Integration  
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
@@ -75,6 +69,7 @@ CI -- Continuous Integration
 <a name="UC-OPMON"></a>**UC-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Daemon Use Case Model. Document ID: [UC-OPMON](../UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md).  
 <a name="TEST-OPMON"></a>**TEST-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Testing Plan. Document ID: [TEST-OPMON](test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md).  
 <a name="IG-SS"></a>**IG-SS** -- Cybernetica AS. X-Road: Security Server Installation Guide. Document ID: [IG-SS](../../Manuals/ig-ss_x-road_v6_security_server_installation_guide.md).  
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Requirements Relevant to Testing
 

--- a/doc/OperationalMonitoring/Testing/test-opmonstrat_x-road_operational_monitoring_testing_strategy_Y-1104-1.md
+++ b/doc/OperationalMonitoring/Testing/test-opmonstrat_x-road_operational_monitoring_testing_strategy_Y-1104-1.md
@@ -52,7 +52,7 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 In this document, we define the testing strategy for the development project of the operational monitoring components of the X-Road system.
 
-A detailed testing plan will be delivered as a separate document in [[TEST-OPMON]](#TEST-OPMON).
+A detailed testing plan will be delivered as a separate document in \[[TEST-OPMON](#TEST-OPMON)\].
 
 ### 1.2 Terms and Abbreviations
 
@@ -69,17 +69,17 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 <a name="UC-OPMON"></a>**UC-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Daemon Use Case Model. Document ID: [UC-OPMON](../UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md).  
 <a name="TEST-OPMON"></a>**TEST-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Testing Plan. Document ID: [TEST-OPMON](test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md).  
 <a name="IG-SS"></a>**IG-SS** -- Cybernetica AS. X-Road: Security Server Installation Guide. Document ID: [IG-SS](../../Manuals/ig-ss_x-road_v6_security_server_installation_guide.md).  
-<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
 
 ## 2 Requirements Relevant to Testing
 
-The functional requirements of the monitoring system are described in [[REC-OPMON]](#REC-OPMON).  
-The architecture of the system is described in [[ARC-OPMOND]](#ARC-OPMOND).  
-The items of data that are collected and forwarded by the monitoring system, are defined in [[HD_1]](#HD_1).  
-The required paths of data exchange are defined in [[HD_1]](#HD_1).  
-The requirements of access control are defined in [[HD_1]](#HD_1).  
-The proper default configuration of the system is defined in [[HD_1]](#HD_1).  
-The non-functional requirements of the monitoring system are described in [[REC-OPMON]](#REC-OPMON) and [[HD_2]](#HD_2).
+The functional requirements of the monitoring system are described in \[[REC-OPMON](#REC-OPMON)\].  
+The architecture of the system is described in \[[ARC-OPMOND](#ARC-OPMOND)\].  
+The items of data that are collected and forwarded by the monitoring system, are defined in \[[HD_1](#HD_1)\].  
+The required paths of data exchange are defined in \[[HD_1](#HD_1)\].  
+The requirements of access control are defined in \[[HD_1](#HD_1)\].  
+The proper default configuration of the system is defined in \[[HD_1](#HD_1)\].  
+The non-functional requirements of the monitoring system are described in \[[REC-OPMON](#REC-OPMON)\] and \[[HD_2](#HD_2)\].
 
 ## 3 Testability of the System
 
@@ -89,11 +89,11 @@ Regular X-Road message exchange as well as monitoring data exchange via all the 
 
 ## 4. Types of Testing Used
 
-The required types of testing are defined in [[HD_4]](#HD_4). In the following sections, all the required types are covered.
+The required types of testing are defined in \[[HD_4](#HD_4)\]. In the following sections, all the required types are covered.
 
 ### 4.1 Integration Testing
 
-The integration tests will be used for testing the required functionality of the security servers and the operational monitoring daemon working together, while regular X-Road requests as well as operational monitoring and health data requests are handled. The goal is to cover the main functionality with automated tests. Manual tests will be carried out by the development team as needed, as well as during acceptance testing if necessary. The descriptions of manual tests will be provided in [[TEST-OPMON]](#TEST-OPMON).
+The integration tests will be used for testing the required functionality of the security servers and the operational monitoring daemon working together, while regular X-Road requests as well as operational monitoring and health data requests are handled. The goal is to cover the main functionality with automated tests. Manual tests will be carried out by the development team as needed, as well as during acceptance testing if necessary. The descriptions of manual tests will be provided in \[[TEST-OPMON](#TEST-OPMON)\].
 
 ### 4.2 Load Requirements and the Scope of Load Tests
 
@@ -102,7 +102,7 @@ The integration tests will be used for testing the required functionality of the
 A general test plan and the requirements for hardware for load testing was specified by RIA by e-mail (message ID `CC0A4AA94EE060438CD300941B8EF1EED37D61@exc2a.ria.ee`), with the following contents:
 
 * As a result of load testing, the throughput of the system is noted. No comparable benchmarks are available. The format of the tests will be suggested by Cybernetica AS.
-* The security servers of the service provider and the service consumer are installed on separate hosts that conform to the minimum requirements defined in [[IG-SS]](#IG-SS).
+* The security servers of the service provider and the service consumer are installed on separate hosts that conform to the minimum requirements defined in \[[IG-SS](#IG-SS)\].
 * Virtual machines can be used during testing -- both by the developers and at RIA's environment.
 * The operational monitoring application is installed at localhost at both security servers and TLS in not used.
 
@@ -126,7 +126,7 @@ Due to the asynchronous nature of the operational monitoring system, the overhea
 
 Under a heavy load and if the operational monitoring database component is unavailable, the monitoring buffer may use a considerable amount of memory or drop the eldest operational data records before having forwarded these to the operational monitoring database component.
 
-Thus, the focus of load testing is to find the balance between memory usage and possible data loss. Details of load testing are provided in [[TEST-OPMON]](#TEST-OPMON).
+Thus, the focus of load testing is to find the balance between memory usage and possible data loss. Details of load testing are provided in \[[TEST-OPMON](#TEST-OPMON)\].
 
 ### 4.3 Unit Testing
 
@@ -140,7 +140,7 @@ Unit tests will not be written for third-party protocol implementations (such as
 
 ## 5 The Team and the Workflow
 
-The schedule of the project and the roles of the team are described in [[PP]](#project_plan).
+The schedule of the project and the roles of the team are described in \[[PP](#project_plan)\].
 
 The testing activities and the programming of tests are carried out by testers and developers. The architecture and the tools of testing are reviewed by the architect of the project.
 
@@ -149,7 +149,7 @@ Unit tests will be implemented by the developers in parallel with the functional
 Integration and load testing will be carried out according to the following plan:
 - *Elaboration phase:* the tools for testing at the required levels will be chosen and an initial testing plan will be written.
 - *Construction phase:* the initial version of load tests will be written and the framework of automated integration tests will be constructed.
-- *Transition phase:* The load tests and the automated integration tests will be implemented and integrated with the Continuous Integration system and the testing environment. If manual integration test cases are written, these will be formatted as part of [[TEST-OPMON]](#TEST-OPMON).
+- *Transition phase:* The load tests and the automated integration tests will be implemented and integrated with the Continuous Integration system and the testing environment. If manual integration test cases are written, these will be formatted as part of \[[TEST-OPMON](#TEST-OPMON)\].
 
 ## 6 Tools, Languages and Libraries
 
@@ -165,7 +165,7 @@ All the source code and the necessary data and configuration files (or samples w
 
 ## 8 Setup and Management of the Testing Environment. Continuous Integration
 
-The testing environment and continuous integration setup during development will closely mimic the required target testing environment (as described in [[HD_4]](#HD_4)) with some additions. The relevant configuration files and documentation will be committed to the main Git development repository for simple migration to the target testing system.
+The testing environment and continuous integration setup during development will closely mimic the required target testing environment (as described in \[[HD_4](#HD_4)\]) with some additions. The relevant configuration files and documentation will be committed to the main Git development repository for simple migration to the target testing system.
 
 ## 8.1 The Servers Used for Automated Testing
 The main automated testing environment consists of the following virtual machines, with the name of the corresponding machine at RIA given in parentheses:

--- a/doc/OperationalMonitoring/UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md
+++ b/doc/OperationalMonitoring/UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md
@@ -4,16 +4,17 @@
 
 # X-Road: Use Case Model for Operational Monitoring Daemon
 
-Version: 0.6  
+Version: 0.7  
 Doc. ID: UC-OPMON
 
 | Date       | Version     | Description                                                                  | Author             |
 |------------|-------------|------------------------------------------------------------------------------|--------------------|
 |  | 0.5       | Initial version               |          |
 | 23.01.2017 | 0.6       | Added license text, table of contents and version history | Sami Kallio |
+| 05.03.2018 | 0.7       | Added terms and abbreviations reference and moved terms to term doc | Tatu Repo |
 
 ## Table of Contents
-
+    
 <!-- toc -->
 
 - [License](#license)
@@ -45,14 +46,15 @@ The use cases include verifications that take place, and the main error conditio
 
 ### 1.2 Terms and Abbreviations
 
-JMX -- Java Management Extensions  
-JMXMP -- Java Management Extensions Messaging Protocol
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
 <a name="ARC-OPMOND"></a>**ARC-OPMOND** -- Cybernetica AS. X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md).  
 <a name="PR-OPMON"></a>**PR-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Protocol. Document ID: [PR-OPMON](../Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md).  
-<a name="PR-OPMONJMX"></a>**PR-OPMONJMX** -- Cybernetica AS. X-Road: Operational Monitoring JMX Protocol. Document ID: [PR-OPMONJMX](../Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).
+<a name="PR-OPMONJMX"></a>**PR-OPMONJMX** -- Cybernetica AS. X-Road: Operational Monitoring JMX Protocol. Document ID: [PR-OPMONJMX](../Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).  
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+
 
 ## 2 Overview
 

--- a/doc/OperationalMonitoring/UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md
+++ b/doc/OperationalMonitoring/UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md
@@ -53,14 +53,14 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 <a name="ARC-OPMOND"></a>**ARC-OPMOND** -- Cybernetica AS. X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md).  
 <a name="PR-OPMON"></a>**PR-OPMON** -- Cybernetica AS. X-Road: Operational Monitoring Protocol. Document ID: [PR-OPMON](../Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md).  
 <a name="PR-OPMONJMX"></a>**PR-OPMONJMX** -- Cybernetica AS. X-Road: Operational Monitoring JMX Protocol. Document ID: [PR-OPMONJMX](../Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md).  
-<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
 
 
 ## 2 Overview
 
 The main function of the operational monitoring daemon is to collect operational monitoring data and health data of the X-Road security server(s). The operational monitoring daemon makes operational and health data available for the owner of the security server, regular client and central monitoring client via security server. Local health data is available for external monitoring systems (e.g. Zabbix) over JMXMP interface.
 
-An overview of the components of the monitoring daemon and its interfaces is provided in [[ARC-OPMOND]](#ARC-OPMOND).
+An overview of the components of the monitoring daemon and its interfaces is provided in \[[ARC-OPMOND](#ARC-OPMOND)\].
 
 ## 3 Use Case Model
 
@@ -252,7 +252,7 @@ The relationships between the actors and use cases are described in Figure 1.
   * 4b.2. Use case continues from step 5.
 
 **Related information:**
-- Operational data SOAP messages must conform to the profile described in document “X-Road: Operational Monitoring Protocol” [[PR-OPMON]](#PR-OPMON).
+- Operational data SOAP messages must conform to the profile described in document “X-Road: Operational Monitoring Protocol” \[[PR-OPMON](#PR-OPMON)\].
 
 
 ### 3.5 UC OPMON_03: Query Security Server Health Data
@@ -338,5 +338,5 @@ The relationships between the actors and use cases are described in Figure 1.
   * 2b.2. Use case continues from step 4.
 
 **Related information:**
-- Health data SOAP messages must conform to the profile described in document “X-Road: Operational Monitoring Protocol” [[PR-OPMON]](#PR-OPMON).
-- Health data JMX messages must confirm to the profile described in document "X-Road: Operational Monitoring JMX Protocol" [[PR-OPMONJMX]](#PR-OPMONJMX).
+- Health data SOAP messages must conform to the profile described in document “X-Road: Operational Monitoring Protocol” \[[PR-OPMON](#PR-OPMON)\].
+- Health data JMX messages must confirm to the profile described in document "X-Road: Operational Monitoring JMX Protocol" \[[PR-OPMONJMX](#PR-OPMONJMX)\].

--- a/doc/Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md
+++ b/doc/Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md
@@ -1,27 +1,28 @@
 # Security server targeting extension for the X-Road message protocol
 
-Version: 1.0  
+Version: 1.1  
 Doc. ID: PR-TARGETSS
 
-| Date      | Version  | Description                                                                  | Author             |
-|-----------|----------|------------------------------------------------------------------------------|--------------------|
-| 2.3.2017 | 1.0       | Initial version                                                              | Olli Lindgren     |
-
+| Date       | Version  | Description                                                                  | Author             |
+|------------|----------|------------------------------------------------------------------------------|--------------------|
+| 02.03.2017 | 1.0      | Initial version                                                              | Olli Lindgren      |
+| 06.03.2018 | 1.1      | Added terms doc reference and link                                           | Tatu Repo          |
 
 ## Table of Contents
 <!-- toc -->
 
 - [License](#license)
-- [Introduction](#introduction)
-- [References](#references)
-- [Format of messages](#format-of-messages)
-  * [Schema header](#schema-header)
-  * [Added `securityServer` element](#added-securityserver-element)
-  * [Message headers](#message-headers)
-- [XML Schema for the extension](#xml-schema-for-the-extension)
-- [Examples](#examples)
-  *  [Request](#request)
-  * [Response](#response)
+- [1 Introduction](#1-introduction)
+  * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+  * [1.2 References](#12-references)
+- [2 Format of messages](#2-format-of-messages)
+  * [2.1 Schema header](#21-schema-header)
+  * [2.2 Added `securityServer` element](#22-added-securityserver-element)
+  * [2.3 Message headers](#23-message-headers)
+- [3 XML Schema for the extension](#3-xml-schema-for-the-extension)
+- [4 Examples](#4-examples)
+  * [4.1 Request](#41-request)
+  * [4.2 Response](#42-response)
 
 <!-- tocstop -->
 
@@ -30,7 +31,7 @@ Doc. ID: PR-TARGETSS
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
 
-## Introduction
+## 1 Introduction
 
 This specification describes an extension of the X-Road protocol for targeting a message to a specific security server.
 
@@ -41,14 +42,19 @@ There is no guarantee about the actual target server &mdash; it can be any of th
 like environmental monitoring \[[ARC-ENVMON](#Ref_ARC-ENVMON)\], where targeting messages to a specific security server is needed.
 Using the `securityServer` element makes this possible.
 
-## References
+### 1.1 Terms and abbreviations
 
-| Code||
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\] 
+
+### 1.2 References
+
+| Document ID||
 | ------------- |-------------|
-| <a name="Ref_PR-MESS"></a>\[PR-MESS\] | Cybernetica AS.X-Road: Message Protocol v4.0      |
-| <a name="Ref_ARC-ENVMON"></a>\[ARC-ENVMON\] | X-Road: Environmental Monitoring Architecture |
+| <a name="Ref_PR-MESS"></a>\[PR-MESS\] | [Cybernetica AS.X-Road: Message Protocol v4.0](../pr-mess_x-road_message_protocol.md)
+| <a name="Ref_ARC-ENVMON"></a>\[ARC-ENVMON\] | [X-Road: Environmental Monitoring Architecture](../../EnvironmentalMonitoring/Monitoring-architecture.md)
+| <a name="Ref_TERMS"></a>\[TA-TERMS\] | [X-Road Terms and Abbreviations](../../terms_x-road_docs.md)
 
-## Format of messages
+## 2 Format of messages
 
 This section describes the XML format for expressing the target security server. The data
 structures and elements defined in this section are in the namespace `http://x-road.eu/xsd/xroad.xsd`. This is the same
@@ -65,7 +71,7 @@ be part of the actual [`http://x-road.eu/xsd/xroad.xsd`](http://x-road.eu/xsd/xr
 The XML Schema for this extension is listed in the section [XML Schema for the extension](#xml-schema-for-the-extension).
 
 
-### Schema header
+### 2.1 Schema header
 
 The following listing shows the header of the schema definition
 
@@ -84,7 +90,7 @@ The following listing shows the header of the schema definition
 
 ```
 
-### Added `securityServer` element
+### 2.2 Added `securityServer` element
 A new `securityServer` element was added to identify the specific target security server.
 
 ```xml
@@ -114,7 +120,7 @@ A new `securityServer` element was added to identify the specific target securit
 </xs:complexType>
 ```
 
-### Message headers
+### 2.3 Message headers
  This section describes the additional SOAP headers that are added by this extension.
 
 |Field | Type | Mandatory/Optional | Description |
@@ -122,7 +128,7 @@ A new `securityServer` element was added to identify the specific target securit
 | securityServer | XRoadSecurityServerIdentifierType | Optional | The security server this message is for |
 
 
-## XML Schema for the extension
+## 3 XML Schema for the extension
  ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema elementFormDefault="qualified"
@@ -144,11 +150,11 @@ A new `securityServer` element was added to identify the specific target securit
 </xs:schema>
 ```
 
-## Examples
+## 4 Examples
 Below are examples from a request and response related to the Environmental Monitoring
 \[[ARC-ENVMON](#Ref_ARC-ENVMON)\] service `getSecurityServerMetrics` which uses the `securityServer` element protocol extension.
 
-### Request
+### 4.1 Request
 ```xml
 <SOAP-ENV:Envelope
     xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
@@ -181,7 +187,7 @@ Below are examples from a request and response related to the Environmental Moni
     </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
 ```
-### Response
+### 4.2 Response
 ```xml
 <SOAP-ENV:Envelope
     xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"

--- a/doc/Protocols/SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md
+++ b/doc/Protocols/SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md
@@ -21,7 +21,7 @@ Doc. ID: PR-SECTOKEN
   * [2.2 Added `securityToken` element](#22-added-securitytoken-element)
   * [2.3 JSON Web Tokens and the `securityToken` attribute `tokenType`](#23-json-web-tokens-and-the-securitytoken-attribute-tokentype)
   * [2.4 Message headers](#24-message-headers)
-- [3 X-Road message logging and the security token](3-x-road-message-logging-and-the-security-token)
+- [3 X-Road message logging and the security token](#3-x-road-message-logging-and-the-security-token)
 - [4 XML Schema for the extension](#4-xml-schema-for-the-extension)
 - [5 Examples](#5-examples)
   * [5.1 Request](#51-request)
@@ -54,7 +54,7 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 | <a name="Ref_UG-SS"></a>\[UG-SS\] | [Security Server User guide](../../Manuals/ug-ss_x-road_6_security_server_user_guide.md)      |
 | <a name="Ref_UG-SYSPAR"></a>\[UG-SYSPAR\] | [X-Road: System Parameters User Guide](../../Manuals/ug-syspar_x-road_v6_system_parameters.md)      |
 | <a name="Ref_JWT-RFC"></a>\[JWT-RFC\] | [Internet Engineering Task Force Request for Comments 7516:  JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)      |
-| <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] | [X-Road Terms and Abbreviations](../terms_x-road_docs.md)
+| <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] | [X-Road Terms and Abbreviations](../../terms_x-road_docs.md)
 
 ## 2 Format of messages
 

--- a/doc/Protocols/SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md
+++ b/doc/Protocols/SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md
@@ -1,28 +1,30 @@
 # Security token extension for the X-Road message protocol
 
-Version: 1.0  
+Version: 1.1  
 Doc. ID: PR-SECTOKEN
 
 | Date       | Version   | Description                                                                  | Author             |
 |------------|-----------|------------------------------------------------------------------------------|--------------------|
 | 20.10.2017 | 1.0       | Initial version                                                              | Olli Lindgren      |
-
+| 06.03.2018 | 1.1       | Added terms section, term doc reference and link                             | Tatu Repo          | 
 
 ## Table of Contents
 
 <!-- toc -->
 
 - [License](#license)
-- [Introduction](#introduction)
-- [References](#references)
-- [Format of messages](#format-of-messages)
-  * [Schema header](#schema-header)
-  * [Added `securityToken` element](#added-securitytoken-element)
-  * [JSON Web Tokens and the `securityToken` attribute `tokenType`](#json-web-tokens-and-the-securitytoken-attribute-tokentype)
-  * [Message headers](#message-headers)
-- [XML Schema for the extension](#xml-schema-for-the-extension)
-- [Examples](#examples)
-  * [Request](#request)
+- [1 Introduction](#1-introduction)
+  * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+  * [1.2 References](#12-references)
+- [2 Format of messages](#2-format-of-messages)
+  * [2.1 Schema header](#21-schema-header)
+  * [2.2 Added `securityToken` element](#22-added-securitytoken-element)
+  * [2.3 JSON Web Tokens and the `securityToken` attribute `tokenType`](#23-json-web-tokens-and-the-securitytoken-attribute-tokentype)
+  * [2.4 Message headers](#24-message-headers)
+- [3 X-Road message logging and the security token](3-x-road-message-logging-and-the-security-token)
+- [4 XML Schema for the extension](#4-xml-schema-for-the-extension)
+- [5 Examples](#5-examples)
+  * [5.1 Request](#51-request)
 
 <!-- tocstop -->
 
@@ -31,7 +33,7 @@ Doc. ID: PR-SECTOKEN
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
 
-## Introduction
+## 1 Introduction
 
 This specification describes an extension of the X-Road protocol for sending loosely defined security tokens as X-Road header data.
 The X-Road message protocol version 4.0 \[[PR-MESS](#Ref_PR-MESS)\] already supports sending arbitrary SOAP headers end-to-end. This
@@ -40,19 +42,21 @@ extension just provides a common, defined way to deliver security tokens with th
 The motivation for the extension was the need to provide a common way to transfer JSON Web Tokens \[[JWT-RFC](#Ref_JWT-RFC)\] over X-Road.
 Examples using JWT as payload in the security token can be found in the [Examples](#examples) section. 
 
+### 1.1 Terms and abbreviations
 
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
-## References
+### 1.2 References
 
-| Code||
+| Document ID||
 | ------------- |-------------|
 | <a name="Ref_PR-MESS"></a>\[PR-MESS\] | [Cybernetica AS.X-Road: Message Protocol v4.0](../pr-mess_x-road_message_protocol.md)      |
 | <a name="Ref_UG-SS"></a>\[UG-SS\] | [Security Server User guide](../../Manuals/ug-ss_x-road_6_security_server_user_guide.md)      |
 | <a name="Ref_UG-SYSPAR"></a>\[UG-SYSPAR\] | [X-Road: System Parameters User Guide](../../Manuals/ug-syspar_x-road_v6_system_parameters.md)      |
 | <a name="Ref_JWT-RFC"></a>\[JWT-RFC\] | [Internet Engineering Task Force Request for Comments 7516:  JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)      |
+| <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] | [X-Road Terms and Abbreviations](../terms_x-road_docs.md)
 
-
-## Format of messages
+## 2 Format of messages
 
 This section describes the XML format for expressing the security token. The data
 structures and elements defined in this section are in the namespace `http://x-road.eu/xsd/security-token.xsd`. The
@@ -63,7 +67,7 @@ Note that at the moment, there is no unifying schema that would combine the mess
 the same namespace. That means there is no single schema that would validate an X-Road message with this extension in use.
 
 
-### Schema header
+### 2.1 Schema header
 
 The following listing shows the header of the schema definition
 
@@ -79,7 +83,7 @@ The following listing shows the header of the schema definition
 
 ```
 
-### Added `securityToken` element
+### 2.2 Added `securityToken` element
 A new `securityToken` element was added to deliver the security token information.
 
 ```xml
@@ -98,7 +102,7 @@ A new `securityToken` element was added to deliver the security token informatio
 
 ```
 
-### JSON Web Tokens and the `securityToken` attribute `tokenType`
+### 2.3 JSON Web Tokens and the `securityToken` attribute `tokenType`
 When transferring JSON Web Tokens, the URI attribute `tokenType` should have the value `urn:ietf:params:oauth:token-type:jwt`
 which is the URI content type for JWT content specified by [section 10.2.1.](https://tools.ietf.org/html/rfc7519#section-10.2.1)
 of the JSON Web Token RFC \[[JWT-RFC](#Ref_JWT-RFC)\]. However, using this value for the `tokenType` is not enforced in any way. The JWT content is not
@@ -106,7 +110,7 @@ currently validated or verified by the security server.
 
 
 
-### Message headers
+### 2.4 Message headers
  This section describes the additional SOAP headers that are added by this extension.
 
 |Field | Mandatory/Optional | Description |
@@ -114,7 +118,7 @@ currently validated or verified by the security server.
 | securityToken | Optional | The security token |
 
 
-## X-Road message logging and the security token
+## 3 X-Road message logging and the security token
 By default, if the message logging add-on (package `xroad-addon-messagelog`) is installed on a security server, all X-Road SOAP messages are logged
 with all their SOAP headers, including the security token. You can read more about the message logging in [Chapter 11](../../Manuals/ug-ss_x-road_6_security_server_user_guide.md#11-message-log)
 of the  the Security Server User Guide \[[UG-SS](#Ref_UG-SS)\].
@@ -123,7 +127,7 @@ In case the security token contains sensitive data that should not be logged, th
 read more about the SOAP body logging options in the [Message log add-on parameters section](../../Manuals/ug-syspar_x-road_v6_system_parameters.md#message-log-add-on-parameters-message-log) of the X-Road System Parameters User
 Guide \[[UG-SYSPAR](#Ref_UG-SYSPAR)\].
 
-## XML Schema for the extension
+## 4 XML Schema for the extension
 The XML Schema for the extension is below. It can also be found at [`http://x-road.eu/xsd/security-token.xsd`](http://x-road.eu/xsd/security-token.xsd) and locally [here](./security-token.xsd).
  ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -149,10 +153,10 @@ The XML Schema for the extension is below. It can also be found at [`http://x-ro
 
 ```
 
-## Examples
+## 5 Examples
 Below is an example request using a JSON Web Token as the security token.
 
-### Request
+### 5.1 Request
 ```xml
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"

--- a/doc/Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md
+++ b/doc/Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 2.7  
+Version: 2.8  
 Doc. ID: PR-GCONF
 
 | Date       | Version     | Description                                                                  | Author             |
@@ -16,7 +16,7 @@ Doc. ID: PR-GCONF
 | 05.09.2016 | 2.5       | Added description of optional configuration parts | Janne Mattila |
 |            | 2.6       | Converted to markdown format |  |
 | 20.01.2017 | 2.7       | Added version history | Sami Kallio |
-
+| 06.03.2018 | 2.8       | Moved terms to term doc, added doc reference and link | Tatu Repo |
 
 ## Table of Contents
 
@@ -77,24 +77,7 @@ The following figure contains a class diagram that illustrates important concept
 
 ![](img/pr-gconf-concepts.png)
 
-- **Configuration Provider** – Entity that maintains a configuration.
-  Configuration provider maintains one or more configuration sources that are used to distribute the configuration.
-- **Configuration Source** – Component that distributes configuration to configuration clients.
-  Configuration source can be either governing authority of an X-Road instance or a configuration proxy.
-- **Configuration Anchor** – Set of information that can be used to download and verify information from a configuration provider.
-  For each source the configuration anchor contains URL and a public key certificate that is used to verify integrity of the downloaded configuration. Configuration anchors are distributed by configuration providers as XML files.
-- **Configuration Client** – Entity that uses configuration anchors for downloading configuration from configuration sources.
-  Configuration clients can be either security servers or configuration proxies.
-- **Configuration Proxy** – Entity that downloads configuration from a configuration source and redistributes them (thus the configuration proxy acts as a configuration source).
-  Typically, the configuration proxy simply caches the configuration. When required, the proxy can also transform the configuration, e.g. by filtering out some data items.
-- **Configuration** – Set of parameters that are distributed by a configuration source.
-  Configuration consists of one or more configuration parts that contain groups of related parameters.
-- **Private Parameters** – Set of parameters that are used only by members of this X-Road instance.
-- **Shared Parameters** – Set of parameters that are used by members of this X-Road instance and other federated instances.
-- **Monitoring Parameters** – (not pictured) Set of parameters that control monitoring of security servers
-- **X-Road Instance** – Installation of the X-Road system. X-Road instances can interact with each other.
-  X-Road instance is run by a governing authority that is responsible for managing members of the X-Road instance and distributing the configuration.
-- **Governing Authority** – Authority that maintains the X-Road instance, registers X-Road members and security servers, and distributes this information to the X-Road members.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 
@@ -105,6 +88,7 @@ The following figure contains a class diagram that illustrates important concept
 - [MPREL] The MIME Multipart/Related Content-type, Internet Engineering Task Force, 1998.
 - [XMLDSIG] XML Signature Syntax and Processing Version 2.0, 2013.
 - [ISO8601] Data Elements and Interchange Formats – Information Interchange – Representation of Dates and Times, International Organization for Standardization, 2004.
+- <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Protocol for Downloading Configuration
 

--- a/doc/Protocols/pr-mess_x-road_message_protocol.md
+++ b/doc/Protocols/pr-mess_x-road_message_protocol.md
@@ -115,11 +115,11 @@ Internet Engineering Task Force, 1997.
 10. <a name="Ref_WRAPPED" class="anchor"></a>\[WRAPPED\] Usage of document/literal wrapped pattern in WSDL design,
 [http://www.ibm.com/developerworks/library/ws-usagewsdl/](http://www.ibm.com/developerworks/library/ws-usagewsdl/).
 
-11. <a name="Ref_PR-TARGETSS" class="anchor"></a>\[PR-TARGETSS\] Security server targeting extension for the X-Road message protocol,
-[local document](./SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md)\.
+11. <a name="Ref_PR-TARGETSS" class="anchor"></a>\[PR-TARGETSS\] Security server targeting extension for the X-Road message protocol. Document ID:
+[PR-TARGETSS](./SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md)\.
 
-12. <a name="Ref_PR-SECTOKEN" class="anchor"></a>\[PR-SECTOKEN\] Security token extension for the X-Road message protocol,
-[local document](./SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md)\.
+12. <a name="Ref_PR-SECTOKEN" class="anchor"></a>\[PR-SECTOKEN\] Security token extension for the X-Road message protocol. Document ID:
+[PR-SECTOKEN](./SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md)\.
 
 13. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 

--- a/doc/Protocols/pr-mess_x-road_message_protocol.md
+++ b/doc/Protocols/pr-mess_x-road_message_protocol.md
@@ -6,8 +6,8 @@
 # X-Road: Message Protocol v4.0
 **Technical Specification**
 
-Version: 4.0.20  
-26.02.2017  
+Version: 4.0.21  
+06.03.2018  
 Doc. ID: PR-MESS
 
 ---
@@ -36,7 +36,8 @@ Doc. ID: PR-MESS
  20.02.2016 | 4.0.18  | Adjusted tables and internal links for better output in PDF                                     | Toomas Mölder
  20.06.2017 | 4.0.19  | SOAPAction HTTP header is preserved                                                             | Jarkko Hyöty
  26.10.2017 | 4.0.20  | Added [Annex H](#annex-h-known-x-road-message-protocol-extensions) on known protocol extensions | Olli Lindgren
-
+ 06.03.2018 | 4.0.21  | Moved terms to term doc, added terms reference and doc link                                     | Tatu Repo
+ 
 ## Table of Contents
 
 <!-- toc -->
@@ -88,14 +89,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### 1.1 Terms and Abbreviations
 
--   **X-Road member** – natural or legal person who uses functionality offered by X-Road
-
--   **Subsystem** – represents part of an information system belonging to an X-Road member. X-Road member can divide its information system to subsystems, although this is not mandatory
-
--   **Central service** – centrally defined alias to a concrete service implemented by an X-Road member or a subsystem.
-
--   **X-Road service** – SOAP-based web service that is offered by an X-Road member or by a subsystem and that can be used by other X-Road members or subsystems.
-
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 
@@ -126,6 +120,8 @@ Internet Engineering Task Force, 1997.
 
 12. <a name="Ref_PR-SECTOKEN" class="anchor"></a>\[PR-SECTOKEN\] Security token extension for the X-Road message protocol,
 [local document](./SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md)\.
+
+13. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ### 1.3 Identifying Entities
 

--- a/doc/Protocols/pr-meta_x-road_service_metadata_protocol.md
+++ b/doc/Protocols/pr-meta_x-road_service_metadata_protocol.md
@@ -6,8 +6,8 @@
 # X-Road: Service Metadata Protocol
 **Technical Specification**
 
-Version: 2.3  
-04.01.2018  
+Version: 2.5 
+06.03.2018  
 Doc. ID: PR-META  
 
 ---
@@ -26,6 +26,7 @@ Doc. ID: PR-META
  02.01.2018 | 2.2     | Update getWsdl metaservice description                          | Ilkka Seppälä
  04.01.2018 | 2.3     | Updated descriptions and subsystem requirements for meta-services | Tatu Repo
  30.01.2018 | 2.4     | Updated metaservices wsdl                                       | Jarkko Hyöty
+ 06.03.2018 | 2.5     | Added terms section, terms doc reference and link                              | Tatu Repo
 
 ## Table of Contents
 
@@ -33,7 +34,8 @@ Doc. ID: PR-META
 
 - [License](#license)
 - [1 Introduction](#1-introduction)
-  * [1.1 References](#11-references)
+  * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+  * [1.2 References](#12-references)
 - [2 Retrieving List of Service Providers](#2-retrieving-list-of-service-providers)
 - [3 Retrieving List of Central Services](#3-retrieving-list-of-central-services)
 - [4 Retrieving List of Services](#4-retrieving-list-of-services)
@@ -65,7 +67,11 @@ This specification does not include option for partially implementing the protoc
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document (in uppercase, as shown) are to be interpreted as described in \[[RFC2119](#Ref_RFC2119)\].
 
-## 1.1 References
+### 1.1 Terms and abbreviations
+
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\]
+
+### 1.2 References
 
 1. <a name="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Message Protocol v4.0,
 [pr-mess_x-road_message_protocol.md](pr-mess_x-road_message_protocol.md)
@@ -73,6 +79,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 [https://www.ietf.org/rfc/rfc2119.txt](https://www.ietf.org/rfc/rfc2119.txt)
 3. <a name="Ref_UG-SYSPAR" class="anchor"></a>\[UG-SYSPAR\] X-Road: System Parameters User Guide,
 [ug-syspar_x-road_v6_system_parameters.md](../Manuals/ug-syspar_x-road_v6_system_parameters.md)
+4. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Retrieving List of Service Providers
 

--- a/doc/Protocols/pr-meta_x-road_service_metadata_protocol.md
+++ b/doc/Protocols/pr-meta_x-road_service_metadata_protocol.md
@@ -6,7 +6,7 @@
 # X-Road: Service Metadata Protocol
 **Technical Specification**
 
-Version: 2.5 
+Version: 2.5  
 06.03.2018  
 Doc. ID: PR-META  
 
@@ -69,16 +69,16 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### 1.1 Terms and abbreviations
 
-See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\]
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 
-1. <a name="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Message Protocol v4.0,
-[pr-mess_x-road_message_protocol.md](pr-mess_x-road_message_protocol.md)
+1. <a name="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Message Protocol v4.0. Document ID:
+[PR-MESS](pr-mess_x-road_message_protocol.md).
 2. <a name="Ref_RFC2119" class="anchor"></a>\[RFC2119\] Key words for use in RFCs to Indicate Requirement Levels, Internet Engineering Task Force, 1997,
 [https://www.ietf.org/rfc/rfc2119.txt](https://www.ietf.org/rfc/rfc2119.txt)
-3. <a name="Ref_UG-SYSPAR" class="anchor"></a>\[UG-SYSPAR\] X-Road: System Parameters User Guide,
-[ug-syspar_x-road_v6_system_parameters.md](../Manuals/ug-syspar_x-road_v6_system_parameters.md)
+3. <a name="Ref_UG-SYSPAR" class="anchor"></a>\[UG-SYSPAR\] X-Road: System Parameters User Guide. Document ID:
+[UG-SYSPAAR](../Manuals/ug-syspar_x-road_v6_system_parameters.md).
 4. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Retrieving List of Service Providers

--- a/doc/Protocols/pr-mserv_x-road_protocol_for_management_services.md
+++ b/doc/Protocols/pr-mserv_x-road_protocol_for_management_services.md
@@ -6,7 +6,7 @@
 
 **Technical Specification**
 
-Version: 1.10  
+Version: 1.11  
 Doc. ID: PR-MSERV
 
 |  Date      | Version |  Description                                                             | Author             |
@@ -29,6 +29,7 @@ Doc. ID: PR-MSERV
 | 30.10.2015 | 1.8     | Header field *userId* removed from management services WSDL              | Kristo Heero       |
 | 11.12.2015 | 1.9     | Corrected documentation about registering only subsystems                | Siim Annuk         |
 | 07.06.2017 | 1.10    | Additional signature algorithms supported                                | Kristo Heero       |
+| 06.03.2018 | 1.11    | Added terms section, term doc reference and link, fixed references       | Tatu Repo          |
 
 ## Table of Contents
 
@@ -36,7 +37,8 @@ Doc. ID: PR-MSERV
 
 * [License](#license)
 * [1 Introduction](#1-introduction)
-    * [1.1 References](#11-references)
+    * [1.1 Terms and abbreviations](#11-terms-and-abbreviations)
+    * [1.2 References](#12-references)
 * [2 Format of the Messages](#2-format-of-the-messages)
     * [2.1 clientReg - Security Server Client Registration](#21-clientreg---security-server-client-registration)
     * [2.2 clientDeletion - Security Server Client Deletion](#22-clientdeletion---security-server-client-deletion)
@@ -67,7 +69,7 @@ Management services are services provided by the X-Road governing organization t
 
 * *authCertDeletion* – removing an authentication certificate from the security server.
 
-The management services are implemented as standard X-Road services (see [[PR-MESS]](#pr-mess) for detailed description of the protocol) that are offered by the X-Road governing authority. The exception is the *authCertReg* service that, for technical reasons, is implemented as HTTPS POST (see below for details).
+The management services are implemented as standard X-Road services (see \[[PR-MESS](#Ref_PR-MESS)\] for detailed description of the protocol) that are offered by the X-Road governing authority. The exception is the *authCertReg* service that, for technical reasons, is implemented as HTTPS POST (see below for details).
 
 This protocol builds on existing transport and message encoding mechanisms. Therefore, this specification does not cover the technical details and error conditions related to making HTTPS requests together with processing MIME-encoded messages. These concerns are discussed in detail in their respective standards.
 
@@ -75,20 +77,24 @@ Section 2 as well as [Annex B](#annex-b-wsdl-file-for-management-services), of t
 
 This specification does not include option for partially implementing the protocol – the conformant implementation must implement the entire specification.
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document (in uppercase, as shown) are to be interpreted as described in [[REQUIREMENT]](#requirement).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document (in uppercase, as shown) are to be interpreted as described in \[[REQUIREMENT](#Ref_REQ)\].
 
-### 1.1 References
+### 1.1 Terms and abbreviations
 
-- [REQUIREMENT] Key words for use in RFCs to Indicate Requirement Levels. Request for Comments 2119, Internet Engineering Task Force, March 1997.
-- [DM-CS] X-Road: Central Server Data Model. Document ID: DM-CS
-- [PR-MESS] X-Road: Message Protocol v4.0. Document ID: PR-MESS
-- [WSDL] Web Services Description Language (WSDL) 1.1. World Wide Web Consortium. 15 March 2001.
-- [DER] DER encoding. ITU-T X.690. July 2002.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
+### 1.2 References
+
+- <a name="Ref_REQ"></a>[REQUIREMENT] Key words for use in RFCs to Indicate Requirement Levels. Request for Comments 2119, Internet Engineering Task Force, March 1997.
+- <a name="Ref_DM-CS"></a>[DM-CS] X-Road: Central Server Data Model. Document ID: [DM-CS](../DataModels/dm-cs_x-road_central_server_configuration_data_model.md)
+- <a name="Ref_PR-MESS"></a>[PR-MESS] X-Road: Message Protocol v4.0. Document ID: [PR-MESS](../Protocols/pr-mess_x-road_message_protocol.md)
+- <a name="Ref_WSDL"></a>[WSDL] Web Services Description Language (WSDL) 1.1. World Wide Web Consortium. 15 March 2001.
+- <a name="Ref_DER"></a>[DER] DER encoding. ITU-T X.690. July 2002.
+- <a name="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Format of the Messages
 
-This section describes the input and output parameters of the management services. The low-level technical details of the services are specified using the WSDL [[WSDL]](#wsdl) syntax. See [Annex  B](#annex-b-wsdl-file-for-management-services) for management services WSDL file.
+This section describes the input and output parameters of the management services. The low-level technical details of the services are specified using the WSDL \[[WSDL](#Ref_WSDL)\] syntax. See [Annex  B](#annex-b-wsdl-file-for-management-services) for management services WSDL file.
 
 ### 2.1 *clientReg* - Security Server Client Registration
 
@@ -100,7 +106,7 @@ The body of the client registration message (request or response) contains the f
 
 * **server** – identifier of the security server where the client is added;
 
-* **requestId** – for responses only, unique identifier of the request that is stored in the central server database [[DM-CS]](#dm-cs).
+* **requestId** – for responses only, unique identifier of the request that is stored in the central server database \[[DM-CS](#Ref_DM-CS)\].
 
 The XML Schema fragment of the client registration request body is shown below. For clarity, documentation in the schema fragment is omitted.
 
@@ -128,7 +134,7 @@ The body of the client deletion message (request or response) contains following
 
 * **server** – identifier of the security server where the client is removed;
 
-* **requestId** – for responses only, unique identifier of the request that is stored in the central server database [[DM-CS]](#dm-cs).
+* **requestId** – for responses only, unique identifier of the request that is stored in the central server database \[[DM-CS](#Ref_DM-CS)\].
 
 The XML Schema fragment of the client deletion request body shown below.
 
@@ -156,9 +162,9 @@ The body of the authentication certificate registration message (request or resp
 
 * **address** – DNS address of the security server;
 
-* **authCert** – contents (in DER encoding [[DER]](#der)) of the authentication certificate that will be added to the security server;
+* **authCert** – contents (in DER encoding \[[DER](#Ref_DER)\]) of the authentication certificate that will be added to the security server;
 
-* **requestId** – for responses only, unique identifier of the request that is stored in the central server database [[DM-CS]](#dm-cs).
+* **requestId** – for responses only, unique identifier of the request that is stored in the central server database \[[DM-CS](#Ref_DM-CS)\].
 
 The XML Schema fragment of the authentication certificate registration request body is shown below. For clarity, documentation in the schema fragment is omitted.
 
@@ -205,7 +211,7 @@ The *authCertDeletion* service is invoked by the security server when an authent
 
 * **authCert** – contents (in DER encoding) of the authentication certificate that is removed from the security server;
 
-* **requestId** – for responses only, unique identifier of the request that is stored in the central server database [[DM-CS]](#dm-cs).
+* **requestId** – for responses only, unique identifier of the request that is stored in the central server database \[[DM-CS](#Ref_DM-CS)\].
 
 The XML Schema fragment of the authentication certificate deletion request body is shown below.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -12,6 +12,8 @@ Index of X-Road Documentation
 - [\[ARC-CS\] Central Server Architecture](Architecture/arc-cs_x-road_central_server_architecture.md)
 - [\[SPEC-AL\] Audit Log Events](Architecture/spec-al_x-road_audit_log_events_1.7_Y-883-17.docx)
 - [\[ARC-TEC\] Technologies used in X-Road](Architecture/arc-tec_x-road_technologies.md)
+- [\[ARC-OPMOND\] Operational Monitoring Daemon Architecture](OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md)
+- [\[ARC-ENVMON\] Environmental Monitoring Architecture](EnvironmentalMonitoring/Monitoring-architecture.md)
 
 ### Protocols
 - [\[PR-MESS\] Message Protocol](Protocols/pr-mess_x-road_message_protocol.md)
@@ -19,19 +21,26 @@ Index of X-Road Documentation
 - [\[PR-MSERV\] Protocol for Management Services](Protocols/pr-mserv_x-road_protocol_for_management_services.md)
 - [\[PR-META\] Service Metadata Protocol](Protocols/pr-meta_x-road_service_metadata_protocol.md)
 - [\[PR-GCONF\] Protocol for Downloading Configuration](Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md)
+- [\[PR-TARGETSS\] Security Server Targeting Extension for the X-Road Message Protocol](Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md)
+- [\[PR-SECTOKEN\] Security Token Extension for the X-Road Message Protocol](Protocols/SecurityTokenExtension/pr-sectoken_security_token_extension_for_the_x-road_protocol.md)
+- [\[PR-OPMON\] Operational Monitoring Protocol](OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md)
+- [\[PR-OPMONJMX\] Operational Monitoring JMX Protocol](OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md)
+- [\[PR-ENVMONMES\] Environmental Monitoring Messages](EnvironmentalMonitoring/Monitoring-messages.md)
 
 ### Manuals
 
-- [\[UG-SS\] Security Server User Guide](Manuals/ug-ss_x-road_6_security_server_user_guide.md)
-- [\[UG-CS\] Central Server User Guide](Manuals/ug-cs_x-road_6_central_server_user_guide.md)
-- [\[UG-SC\] Signer Console Users Guide](Manuals/ug-sc_x-road_signer-console_users_guide_2.5_Y-883-20.docx)
 - [\[IG-SS\] Security Server Installation Guide](Manuals/ig-ss_x-road_v6_security_server_installation_guide.md)
 - [\[IG-CS\] Central Server Installation Guide](Manuals/ig-cs_x-road_6_central_server_installation_guide.md)
 - [\[IG-CSHA\] HA Installation Guide](Manuals/ig-csha_x-road_6_ha_installation_guide.md)
+- [\[IG-XLB\] External Load Balancer Installation Guide](Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md)
+- [\[UG-SS\] Security Server User Guide](Manuals/ug-ss_x-road_6_security_server_user_guide.md)
+- [\[UG-CS\] Central Server User Guide](Manuals/ug-cs_x-road_6_central_server_user_guide.md)
+- [\[UG-SC\] Signer Console Users Guide](Manuals/ug-sc_x-road_signer-console_users_guide_2.5_Y-883-20.docx)
 - [\[UG-SIGDOC\] Signed Document Download and Verification Manual](Manuals/ug-sigdoc_x-road_signed_document_download_and_verification_manual_1.4.1_Y-883-21.docx)
 - [\[UG-CP\] Configuration Proxy Manual](Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md)
 - [\[UG-SYSPAR\] System Parameters](Manuals/ug-syspar_x-road_v6_system_parameters.md)
-- [\[IG-XLB\] External Load Balancer Installation Guide](Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md)
+- [\[UG-OPMONSYSPAR\] Operational Monitoring System Parameters](OperationalMonitoring/Manuals/ug-opmonsyspar_x-road_operational_monitoring_system_parameters_Y-1099-1.md)
+
 
 ### Use Cases
 - [\[UC-SS\] Security Server Management](UseCases/uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md)
@@ -43,6 +52,7 @@ Index of X-Road Documentation
 - [\[UC-TRUST\] Trust Service Management](UseCases/uc-trust_x-road_use_case_model_for_trust_service_management_1.1.1_Y-883-9.md)
 - [\[UC-MESS\] Member Communication](UseCases/uc-mess_x-road_member_communication_use_case_model.md)
 - [\[UC-SERVICE\] Service Management](UseCases/uc-service_x-road_use_case_model_for_service_management_1.6_Y-883-3.md)
+- [\[UC-OPMON\] Use Case Model for Operational Monitoring Daemon](OperationalMonitoring/UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md)
 
 ### Data Models
 
@@ -50,6 +60,7 @@ Index of X-Road Documentation
 - [\[DM-CS\] Central Server Configuration](DataModels/dm-cs_x-road_central_server_configuration_data_model.md)
 - [\[DM-ML\] Message Log](DataModels/dm-ml_x-road_message_log_data_model.md)
 
-### Monitoring
-- [\[ARC-ENVMON\] Environmental Monitoring Architecture](EnvironmentalMonitoring/Monitoring-architecture.md)
-- [\[PR-ENVMONMES\] Environmental Monitoring Messages](EnvironmentalMonitoring/Monitoring-messages.md)
+### Testing
+
+- [\[TEST-OPMON\] Operational Monitoring Testing Plan](OperationalMonitoring/Testing/test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md)
+- [\[TEST-OPMONSTRAT\] Operational Monitoring Testing Strategy](OperationalMonitoring/Testing/test-opmonstrat_x-road_operational_monitoring_testing_strategy_Y-1104-1.md)

--- a/doc/UseCases/uc-cp_x-road_configuration_proxy_use_case_model_1.2_Y-883-5.md
+++ b/doc/UseCases/uc-cp_x-road_configuration_proxy_use_case_model_1.2_Y-883-5.md
@@ -4,8 +4,8 @@
 # X-Road: Configuration Proxy Use Case Model
 **Analysis**
 
-Version: 1.3
-29.08.2017
+Version: 1.4  
+07.03.2018
 <!-- 20 pages -->
 Doc. ID: UC-CP
 --------------------------------------------
@@ -22,6 +22,7 @@ Date       | Version | Description                                              
 08.11.2015 |  1.1    |   Renamed *Scope* element to *System*. *Native* (X-Road instance) renamed to *local*. Minor corrections done.   | Riin Saarmäe
 14.12.2015 |  1.2    |   UC CP\_06 fixed                                                                                               | Riin Saarmäe
 29.08.2017 |  1.3    |   Changed documentation type from docx to md file |   Lasse Matikainen
+07.03.2018 |  1.4    |   Moved terms to term doc, added term doc reference and link | Tatu Repo
 
 ## Table of Contents
 
@@ -85,15 +86,15 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)]\.
     <http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/csprd01/pkcs11-base-v2.40-csprd01.html#_Toc372627249>
 
 2.  <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] X-Road: Protocol for
-    Downloading Configuration. Document ID: PR-GCONF.
+    Downloading Configuration. Document ID: [PR-GCONF](../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md).
 
 3.  <a id="Ref_UG-CP" class="anchor"></a>\[UG-CP\] X-Road: Configuration Proxy Manual.
-    Document ID: UG-CP.
+    Document ID: [UG-CP](../Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md).
 
 4.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] X-Road: Use Case Model for
-    Global Configuration Distribution. Document ID: UC-GCONF.
+    Global Configuration Distribution. Document ID: [UC-GCONF](uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md).
     
-5. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
+5.  <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Overview
 

--- a/doc/UseCases/uc-cp_x-road_configuration_proxy_use_case_model_1.2_Y-883-5.md
+++ b/doc/UseCases/uc-cp_x-road_configuration_proxy_use_case_model_1.2_Y-883-5.md
@@ -76,64 +76,7 @@ The use cases including a human actor (the *level* of the use case is
 
 ### 1.2 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at
-<https://confluence.ria.ee/display/XROADDOCS/Terms%2C+definitions+and+abbrevations>.
-
-This section defines the terms that are not defined in the
-aforementioned document or that have contextual meaning specific to this
-document in addition to the general definition.
-
--   **Configuration provider** is an entity responsible for maintaining
-    and distributing global configuration. The configuration provider
-    manages one or two configuration sources through which configuration
-    is made available for configuration clients. In an X-Roads system,
-    the central server and the configuration proxy act as configuration
-    providers.
-
--   **Central server** is the primary configuration source in an X-Road
-    system. Central server always manages an internal configuration
-    source (i.e. configuration source distributing the internal
-    configuration) and in addition, an external configuration source
-    (i.e. configuration source distributing the external configuration)
-    in case the X-Road system is federation-capable.
-
--   **Configuration proxy** may optionally be used to mediate
-    configuration originating from the central server to the
-    configuration clients. Configuration proxy manages configuration
-    sources that are used to distribute configuration downloaded from
-    other configuration sources.
-
--   **Configuration source** is a component (HTTP server) managed by a
-    configuration provider. The configuration distributed by the source
-    can either be internal configuration or external configuration. The
-    information needed to access and download configuration from a
-    source is contained in the configuration anchor.
-
--   **Configuration anchor** is a set of information that can be used by
-    configuration clients to access a configuration source and to verify
-    the downloaded configuration. The configuration anchor is
-    distributed as either a separate XML file in case the anchor points
-    to a local configuration source or as a part of private parameters
-    in case the anchor points to the configuration source managed by a
-    federation partner.
-
--   **Configuration client** is an entity that uses configuration
-    anchor(s) for downloading configuration from configuration
-    source(s). In an X-Roads system, security server and configuration
-    proxy act as configuration clients.
-
--   **Security server** is a configuration client that uses a
-    configuration anchor provided by the internal configuration provider
-    to download internal configuration from its local configuration
-    source. Subsequently, in case of federated X-Road systems, the
-    security server uses configuration anchors contained in the private
-    parameters part of the downloaded internal configuration to download
-    the external configuration of X-Road systems federated with the
-    local system.
-
--   **Trusted anchor** is a configuration anchor that points to a
-    configuration source and has been uploaded to the configuration
-    proxy.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)]\.
 
 ### 1.3 References
 
@@ -149,6 +92,8 @@ document in addition to the general definition.
 
 4.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] X-Road: Use Case Model for
     Global Configuration Distribution. Document ID: UC-GCONF.
+    
+5. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Overview
 

--- a/doc/UseCases/uc-cs_x-road_use_case_model_for_central_server_management_1.2_Y-883-6.md
+++ b/doc/UseCases/uc-cs_x-road_use_case_model_for_central_server_management_1.2_Y-883-6.md
@@ -5,8 +5,8 @@
 # X-Road: Use Case Model for Central Server Management
 **Analysis**
 
-Version: 1.4
-19.02.2018
+Version: 1.5
+06.03.2018
 <!-- 38 pages -->
 Doc. ID: UC-CS
 ------------------------------------------------------
@@ -23,6 +23,7 @@ Date       | Version | Description                                              
 13.12.2015 |  1.2    |   Restore clears the shared memory (UC CS\_08)                                                                                            |   Riin Saarmäe
 29.08.2017 |  1.3    |  Changed documentation type from docx to md file | Lasse Matikainen
 19.02.2018 |  1.4    |   Updated the negative case extension for backing up the central server | Tatu Repo
+06.03.2018 |  1.5    |   Added term doc reference and link, added reference links | Tatu Repo
 
 ## Table of Contents
 
@@ -88,31 +89,32 @@ system and has the access rights required to carry out the use case.
 
 ### 1.1 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at
-<https://confluence.ria.ee/display/XROADDOCS/Terms%2C+definitions+and+abbrevations>.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 
 1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\]
-    X-Road 6. Central Server Installation Guide. Document ID: IG-CS.
+    X-Road 6. Central Server Installation Guide. Document ID: [IG-CS](../Manuals/ig-cs_x-road_6_central_server_installation_guide.md).
 
 2.  <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] X-Road:
     Audit Log Events. Document ID: SPEC-AL.
 
 3.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] X-Road: Use Case Model for
-    Global Configuration Distribution. Document ID: UC-GCONF.
+    Global Configuration Distribution. Document ID: [UC-GCONF](uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md).
 
 4.  <a id="Ref_UC-FED" class="anchor"></a>\[UC-FED\] X-Road: Use Case Model for
-    Federation. Document ID: UC-FED.
+    Federation. Document ID: [UC-FED](uc-fed_x-road_use_case_model_for_federation_1.1_Y-883-7.md).
 
 5.  <a id="Ref_UC-MEMBER" class="anchor"></a>\[UC-MEMBER\] X-Road: Use Case Model for
-    Member Management. Document ID: UC-MEMBER.
+    Member Management. Document ID: [UC-MEMBER](uc-member_x-road_use_case_model_for_member_management.md).
 
 6.  <a id="Ref_UC-SERVICE" class="anchor"></a>\[UC-SERVICE\] X-Road: Use Case Model for
-    Service Management. Document ID: UC-SERVICE.
+    Service Management. Document ID: [UC-SERVICE](uc-service_x-road_use_case_model_for_service_management_1.6_Y-883-3.md).
 
 7.  <a id="Ref_UC-TRUST" class="anchor"></a>\[UC-TRUST\] X-Road: Use Case Model for
-    Trust Service Management. Document ID: UC-TRUST.
+    Trust Service Management. Document ID: [UC-TRUST](uc-trust_x-road_use_case_model_for_trust_service_management_1.1.1_Y-883-9.md).
+
+8.  <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Use Case Model
 

--- a/doc/UseCases/uc-cs_x-road_use_case_model_for_central_server_management_1.2_Y-883-6.md
+++ b/doc/UseCases/uc-cs_x-road_use_case_model_for_central_server_management_1.2_Y-883-6.md
@@ -5,7 +5,7 @@
 # X-Road: Use Case Model for Central Server Management
 **Analysis**
 
-Version: 1.5
+Version: 1.5  
 06.03.2018
 <!-- 38 pages -->
 Doc. ID: UC-CS

--- a/doc/UseCases/uc-fed_x-road_use_case_model_for_federation_1.1_Y-883-7.md
+++ b/doc/UseCases/uc-fed_x-road_use_case_model_for_federation_1.1_Y-883-7.md
@@ -6,8 +6,8 @@
 # X-Road: Use Case Model for Federation
 **Analysis**
 
-Version: 1.3
-06.03.2017
+Version: 1.3  
+06.03.2018
 <!-- 15 pages -->
 Doc. ID: UC-FED
 

--- a/doc/UseCases/uc-fed_x-road_use_case_model_for_federation_1.1_Y-883-7.md
+++ b/doc/UseCases/uc-fed_x-road_use_case_model_for_federation_1.1_Y-883-7.md
@@ -6,8 +6,8 @@
 # X-Road: Use Case Model for Federation
 **Analysis**
 
-Version: 1.2
-29.08.2017
+Version: 1.3
+06.03.2017
 <!-- 15 pages -->
 Doc. ID: UC-FED
 
@@ -22,7 +22,7 @@ Doc. ID: UC-FED
 20.09.2015  | 1.0     |  Editorial changes made                                         | Imbi Nõgisto
 08.11.2015  | 1.1     |  Renamed *Scope* element to *System*. *Native* (X-Road instance) renamed to *local*. Minor corrections done. |   Riin Saarmäe
 29.08.2017  | 1.2     |  Changed documentation type from docx to md file |   Lasse Matikainen
-
+06.03.2018  | 1.3     |  Moved terms to term doc, added term doc reference and link, added internal MD-doc links | Tatu Repo
 
 ## Table of Contents
 
@@ -69,108 +69,23 @@ the access rights required to carry out the use case.
 
 ### 1.2 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at
-<https://confluence.ria.ee/display/XROADDOCS/Terms%2C+definitions+and+abbrevations>.
-
-This section defines the terms that are not defined in the
-aforementioned document or that have contextual meaning specific to this
-document in addition to the general definition.
-
--   **Central server** is the primary configuration source in an X-Road
-    system. Central server always manages an internal configuration
-    source (i.e. configuration source distributing the internal
-    configuration) and in addition, an external configuration source
-    (i.e. configuration source distributing the external configuration)
-    in case the X-Road system is federation-capable.
-
--   **Configuration anchor** is a set of information that can be used by
-    configuration clients to access a configuration source and to verify
-    the downloaded configuration. The configuration anchor is
-    distributed to the configuration clients as either a separate XML
-    file in case the anchor points to a local configuration source or as
-    a part of private parameters in case the anchor points to the
-    configuration source managed by a federation partner.
-
--   **Configuration client** is an entity that uses configuration
-    anchor(s) for downloading configuration from configuration
-    source(s). In an X-Roads system, security server and configuration
-    proxy act as configuration clients.
-
--   **Configuration part (file)** is an XML file containing system
-    parameters.
-
--   **Configuration provider** is an entity responsible for maintaining
-    and distributing configuration. Configuration provider manages one
-    or two configuration sources through which configuration is made
-    available for configuration clients. In an X-Roads system, central
-    server and configuration proxy act as configuration providers.
-
--   **Configuration proxy** may optionally be used to mediate
-    configuration originating from the central server to the
-    configuration clients. Configuration proxy manages a single
-    configuration source that is used to distribute configuration
-    downloaded from another configuration source. The configuration
-    mediated by the proxy may either be internal or external
-    configuration, depending on the proxy's purpose.
-
--   **Configuration source** is a component (HTTP server) managed by a
-    configuration provider. The configuration distributed by the source
-    can either be internal configuration or external configuration. The
-    information needed to access and download configuration from a
-    source is contained in the configuration anchor.
-
--   **External configuration** is distributed by a configuration source
-    and only contains the shared parameters configuration part.
-
--   **Internal configuration** is distributed by a configuration source
-    and is composed of the following configuration parts: private
-    parameters; shared parameters, and; optionally, other configuration
-    parts that are specific to an X-Road instance – optional parameters.
-
--   **Private parameters** is a configuration part that holds system
-    parameters that are only used by security servers that are part of
-    the local X-Road system (i.e. the same X-Road system as the central
-    server the configuration part originates from). In case of federated
-    X-Road systems, the private parameters contain configuration anchors
-    pointing to configuration sources distributing external
-    configuration of federation partners.
-
--   **Security server** is a configuration client that uses a root
-    configuration anchor to download internal configuration from its
-    local configuration source. Subsequently, in case of federated
-    X-Road systems, the security server uses configuration anchors
-    contained in the private parameters part of the downloaded internal
-    configuration to download the external configuration of X-Road
-    systems federated with the local system.
-
--   **Shared parameters** is a configuration part that holds system
-    parameters that are used both by the security servers of the local
-    X-Road system and by the security servers belonging to X-Road
-    systems federated with the local system.
-
--   **System configuration** consists of data stored in the database,
-    and in the various configuration files held in the file system of an
-    X-Road component.
-
--   **Trusted anchor** is a configuration anchor that points to the
-    external configuration source of a federation partner and has been
-    uploaded to the central server during the federation process.
-    Trusted anchors are distributed to the configuration clients of the
-    local X-Road system as a part of private parameters.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
 1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] X-Road 6. Central Server
-    Installation Guide. Document ID: IG-CS.
+    Installation Guide. Document ID: [IG-CS](../Manuals/ig-cs_x-road_6_central_server_installation_guide.md).
 
 2.  <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] X-Road: Protocol for
-    Downloading Configuration. Document ID: PR-GCONF.
+    Downloading Configuration. Document ID: [PR-GCONF](../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md).
 
 3.  <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] X-Road: Audit Log Events.
     Document ID: SPEC-AL.
 
 4.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] X-Road: Use Case Model for
-    Global Configuration Distribution. Document ID: UC-GCONF.
+    Global Configuration Distribution. Document ID: [UC-GCONF](uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md).
+    
+5.  <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Overview
 

--- a/doc/UseCases/uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md
+++ b/doc/UseCases/uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md
@@ -5,7 +5,7 @@
 # X-Road: Use Case Model for Global Configuration Distribution
 **Analysis**
 
-Version: 1.6
+Version: 1.6  
 06.03.2018
 <!-- 36 pages -->
 Doc. ID: UC-GCONF

--- a/doc/UseCases/uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md
+++ b/doc/UseCases/uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md
@@ -5,8 +5,8 @@
 # X-Road: Use Case Model for Global Configuration Distribution
 **Analysis**
 
-Version: 1.5
-29.08.2017
+Version: 1.6
+06.03.2018
 <!-- 36 pages -->
 Doc. ID: UC-GCONF
 
@@ -29,6 +29,7 @@ Date       | Version | Description                                              
 16.12.2015 |  1.3    |  GCONF\_11 updated: a label value can be assigned for the key on generation. UC GCONF\_24 updated: the last successful configuration source is used for downloading configuration, if the download from the last successful source fails then the next source is chosen randomly.   | Riin Saarmäe
 12.02.2016 |  1.4    |  GCONF\_22 updated: the verification of the instance identifier on configuration anchor file upload added.                                                                                                                                                                           | Meril Vaht
 29.08.2017 | 1.5     |  Changed documentation type from docx to md file |   Lasse Matikainen
+06.03.2018 | 1.6     |  Moved terms to term doc, added term doc reference and link, added internal MD-doc links | Tatu Repo
 
 ## Table of Contents
 
@@ -112,100 +113,15 @@ the access rights required to carry out the use case.
 
 ### 1.2 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at
-<https://confluence.ria.ee/display/XROADDOCS/Terms%2C+definitions+and+abbrevations>.
-
-This section defines the terms that are not defined in the
-aforementioned document or that have contextual meaning specific to this
-document in addition to the general definition.
-
--   **Central server** is the primary configuration source in an X-Road
-    system. Central server always manages an internal configuration
-    source (i.e. configuration source distributing the internal
-    configuration) and in addition, an external configuration source
-    (i.e. configuration source distributing the external configuration)
-    in case the X-Road system is federation-capable.
-
--   **Configuration anchor** is a set of information that can be used by
-    configuration clients to access a configuration source and to verify
-    the downloaded configuration. The configuration anchor is
-    distributed as either a separate XML file in case the anchor points
-    to a local configuration source or as a part of private parameters
-    in case the anchor points to the configuration source managed by a
-    federation partner.
-
--   **Configuration client** is an entity that uses configuration
-    anchor(s) for downloading configuration from configuration
-    source(s). In an X-Roads system, security server and configuration
-    proxy act as configuration clients.
-
--   **Configuration part (file)** is an XML file containing system
-    parameters.
-
--   **Configuration provider** is an entity responsible for maintaining
-    and distributing global configuration. The configuration provider
-    manages one or two configuration sources through which configuration
-    is made available for configuration clients. In an X-Roads system,
-    the central server and the configuration proxy act as configuration
-    providers.
-
--   **Configuration proxy** may optionally be used to mediate
-    configuration originating from the central server to the
-    configuration clients. Configuration proxy manages configuration
-    sources, that are used to distribute configuration downloaded from
-    other configuration sources.
-
--   **Configuration source** is a component (HTTP server) managed by a
-    configuration provider. The configuration distributed by the source
-    can either be internal configuration or external configuration. The
-    information needed to access and download configuration from a
-    source is contained in the configuration anchor.
-
--   **External configuration** is distributed by a configuration source
-    and only contains the shared parameters configuration part.
-
--   **Internal configuration** is distributed by a configuration source
-    and is composed of the following configuration parts: private
-    parameters; shared parameters, and; optionally, other configuration
-    parts that are specific to an X-Road instance – optional parameters.
-
--   **Optional parameters** is an optional configuration part that
-    carries system parameters that have a contextual meaning only to a
-    specific X-Road system installation.
-
--   **Private parameters** is a configuration part that holds system
-    parameters that are only used by security servers that are part of
-    the local X-Road system (i.e. the same X-Road system as the central
-    server the configuration part originates from). In case of federated
-    X-Road systems, the private parameters contain configuration anchors
-    pointing to configuration sources distributing external
-    configuration of federation partners.
-
--   **Security server** is a configuration client that uses a
-    configuration anchor provided by the internal configuration provider
-    to download internal configuration from its local configuration
-    source. Subsequently, in case of federated X-Road systems, the
-    security server uses configuration anchors contained in the private
-    parameters part of the downloaded internal configuration to download
-    the external configuration of X-Road systems federated with the
-    local system.
-
--   **Shared parameters** is a configuration part that holds system
-    parameters that are used both by the security servers of the local
-    X-Road system and by the security servers belonging to X-Road
-    systems federated with the local system.
-
--   **System configuration** consists of data stored in the database and
-    in the various configuration files held in the file system of an
-    X-Road component.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
 1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] X-Road 6. Central Server
-    Installation Guide. Document ID: IG-CS.
+    Installation Guide. Document ID: [IG-CS](../Manuals/ig-cs_x-road_6_central_server_installation_guide.md).
 
 2.  <a id="Ref_IG-SS" class="anchor"></a>\[IG-SS\] X-Road 6. Security Server
-    Installation Guide. Document ID: IG-SS.
+    Installation Guide. Document ID: [IG-SS](../Manuals/ig-ss_x-road_v6_security_server_installation_guide.md).
 
 3.  <a id="Ref_INI" class="anchor"></a>\[INI\] INI file.
     <http://en.wikipedia.org/wiki/INI_file>
@@ -215,19 +131,21 @@ document in addition to the general definition.
     <http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/csprd01/pkcs11-base-v2.40-csprd01.html#_Toc372627249>
 
 5.  <a id="Ref_PR-GCONF" class="anchor"></a>\[PR-GCONF\] X-Road: Protocol for
-    Downloading Configuration. Document ID: PR-GCONF.
+    Downloading Configuration. Document ID: [PR-GCONF](../Protocols/pr-gconf_x-road_protocol_for_downloading_configuration.md).
 
 6.  <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] X-Road:
     Audit Log Events. Document ID: SPEC-AL.
 
 7.  <a id="Ref_UC-CP" class="anchor"></a>\[UC-CP\] X-Road: Use Case Model for the
-    Configuration Proxy. Document ID: UC-CP.
+    Configuration Proxy. Document ID: [UC-CP](uc-cp_x-road_configuration_proxy_use_case_model_1.2_Y-883-5.md).
 
 8.  <a id="Ref_UC-FED" class="anchor"></a>\[UC-FED\] X-Road: Use Case Model for
-    Federation. Document ID: UC-FED.
+    Federation. Document ID: [UC-FED](uc-fed_x-road_use_case_model_for_federation_1.1_Y-883-7.md).
 
 9.  <a id="Ref_UG-SYSPAR" class="anchor"></a>\[UG-SYSPAR\] X-Road:
-    System Parameters. Document ID: UG-SYSPAR.
+    System Parameters. Document ID: [UG-SYSPAR](../Manuals/ug-syspar_x-road_v6_system_parameters.md).
+
+10. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Overview
 

--- a/doc/UseCases/uc-member_x-road_use_case_model_for_member_management.md
+++ b/doc/UseCases/uc-member_x-road_use_case_model_for_member_management.md
@@ -6,8 +6,8 @@
 # X-Road: Use Case Model for Member Management
 **Analysis**
 
-Version: 1.5
-23.02.2017
+Version: 1.7  
+06.03.2018
 <!--  63 pages -->
 Doc. ID: UC-MEMBER
 
@@ -29,6 +29,7 @@ Doc. ID: UC-MEMBER
  16.12.2015 | 1.3     | [UC MEMBER\_56](#2311-uc-member_56-add-a-subsystem-to-an-x-road-member) and [UC MEMBER\_57](#2332-uc-member_57-register-the-management-service-provider-as-a-security-server-client) added. Only subsystems (and not members) can be added and registered as security server clients. [UC MEMBER\_32](#2330-uc-member_32-view-the-configuration-for-management-services) and [UC MEMBER\_28](#2326-uc-member_28-handle-an-authentication-certificate-registration-request) updated. Minor corrections done.  | Riin Saarmäe
  24.11.2016 | 1.4     | XTE-297: Internal Servers tab is displayed to security server owner | Meril Vaht
  23.02.2017 | 1.6     | Converted to Github flavoured Markdown, added license text, adjusted tables and identification for better output in PDF | Toomas Mölder 
+ 06.03.2018 | 1.7     | Moved terms to term doc, added term doc reference and link, added internal MD-doc links | Tatu Repo
 
 ## Table of Contents
 
@@ -135,37 +136,31 @@ The use cases including a human actor (the *level* of the use case is *user task
 
 ### 1.2 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at <[Terms of X-Road](../terms_x-road_docs.md)>.
-
-This section defines the terms that are not defined in the aforementioned document or that have contextual meaning specific to this document in addition to the general definition.
-
--   **Internal TLS certificates** are used for setting up the TLS connection between the security server and the client information systems.
-
--   **System configuration** consists of data stored in the database and in the various configuration files held in the file system of an X-Road component.
-
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
-1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] X-Road 6. Central Server Installation Guide. Document ID: IG-CS.
+1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] X-Road 6. Central Server Installation Guide. Document ID: [IG-CS](../Manuals/ig-cs_x-road_6_central_server_installation_guide.md).
 
-2.  <a id="Ref_IG-SS" class="anchor"></a>\[IG-SS\] X-Road 6. Security Server Installation Guide. Document ID: IG-SS.
+2.  <a id="Ref_IG-SS" class="anchor"></a>\[IG-SS\] X-Road 6. Security Server Installation Guide. Document ID: [IG-SS](../Manuals/ig-ss_x-road_v6_security_server_installation_guide.md).
 
-3.  <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\] X-Road: Protocol for Management Services. Document ID: PR-MSERV.
+3.  <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\] X-Road: Protocol for Management Services. Document ID: [PR-MSERV](../Protocols/pr-mserv_x-road_protocol_for_management_services.md).
 
 4.  <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] X-Road: Audit Log Events. Document ID: SPEC-AL.
 
-5.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] X-Road: Use Case Model for Global Configuration Distribution. Document ID: UC-GCONF.
+5.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] X-Road: Use Case Model for Global Configuration Distribution. Document ID: [UC-GCONF](uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md).
 
-6.  <a id="Ref_UC-MESS" class="anchor"></a>\[UC-MESS\] X-Road: Use Case Model for Member Communication. Document ID: UC-MESS.
+6.  <a id="Ref_UC-MESS" class="anchor"></a>\[UC-MESS\] X-Road: Use Case Model for Member Communication. Document ID: [UC-MESS](uc-mess_x-road_member_communication_use_case_model.md).
 
-7.  <a id="Ref_UC-SERVICE" class="anchor"></a>\[UC-SERVICE\] X-Road: Use Case Model for Service Management. Document ID: UC-SERVICE.
+7.  <a id="Ref_UC-SERVICE" class="anchor"></a>\[UC-SERVICE\] X-Road: Use Case Model for Service Management. Document ID: [UC-SERVICE](uc-service_x-road_use_case_model_for_service_management_1.6_Y-883-3.md).
 
-8.  <a id="Ref_UC-SS" class="anchor"></a>\[UC-SS\] X-Road: Use Case Model for Security Server Management. Document ID: UC-SS.
+8.  <a id="Ref_UC-SS" class="anchor"></a>\[UC-SS\] X-Road: Use Case Model for Security Server Management. Document ID: [UC-SS](uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md).
 
-9.  <a id="Ref_UG-SS" class="anchor"></a>\[UG-SS\] X-Road 6. Security Server User Guide. Document ID: UG-SS.
+9.  <a id="Ref_UG-SS" class="anchor"></a>\[UG-SS\] X-Road 6. Security Server User Guide. Document ID: [UG-SS](../Manuals/ug-ss_x-road_6_security_server_user_guide.md).
 
 10. <a id="Ref_X509" class="anchor"></a>\[X509\] Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile, Internet Engineering Task Force, 2008.
 
+11. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Use Case Model
 

--- a/doc/UseCases/uc-mess_x-road_member_communication_use_case_model.md
+++ b/doc/UseCases/uc-mess_x-road_member_communication_use_case_model.md
@@ -6,8 +6,8 @@
 
 **Analysis**
 
-Version: 1.6
-22.02.2017
+Version: 1.7
+06.03.2018
 <!-- 38 pages -->
 Doc. ID: UC-MESS
 
@@ -29,6 +29,7 @@ Doc. ID: UC-MESS
  05.02.2016 | 1.4     | XTE-225 - use case [MESS\_04](#35-uc-mess_04-verify-soap-message) updated.                            | Meril Vaht
  14.12.2016 | 1.5     | Operational monitoring functionality added                      | Meril Vaht
  22.02.2017 | 1.6     | Converted to Github flavoured Markdown, added license text, adjusted tables and identification for better output in PDF, re-numbered and re-bulleted [MESS\_16](#317-uc-mess_16-store-operational-monitoring-data-and-forward-the-data-to-operational-monitoring-daemon)| Toomas Mölder
+ 06.03.2018 | 1.7     | Moved terms to term doc, added term doc reference and link, added internal MD-doc links | Tatu Repo
 
 ## Table of Contents
 
@@ -76,18 +77,7 @@ The purpose of this document is to describe the events and verifications that ta
 
 ### 1.2 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at <https://confluence.ria.ee/display/XROADDOCS/Terms%2C+definitions+and+abbrevations>.
-
-The following terms are used in this document in addition to the general terms:
-
--   **System configuration** consists of data stored in the database, and in the various configuration files held in the file system of an X-Road component.
-
--   **TLS certificate** is a certificate used by the security server to authenticate the information system when HTTPS protocol is used for connections between the service client's or service provider's security server and information system.
-
--   **Operational monitoring data** contains operational data (such as which services have been called, how many times, what was the size of the response, etc.) of the X-Road security server(s).
-
--   **Operational monitoring daemon** collects and shares operational monitoring data of the X-Road security server(s), calculates and shares health data of the X-Road security server(s) that is based on collected operational monitoring data.
-
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
@@ -95,26 +85,27 @@ The following terms are used in this document in addition to the general terms:
 
 2.  <a id="Ref_HPDS" class="anchor"></a>\[HPDS\] Freudenthal, M. Profile for High-Perfomance Digital Signature. T-4-23, 2015. <http://cyber.ee/en/research/publications/research-reports/>
 
-3.  <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Message Protocol v4.0. Document ID: PR-MESS.
+3.  <a id="Ref_PR-MESS" class="anchor"></a>\[PR-MESS\] Cybernetica AS. X-Road: Message Protocol v4.0. Document ID: [PR-MESS](../Protocols/pr-mess_x-road_message_protocol.md).
 
-4.  <a id="Ref_PR-MESSTRANSP" class="anchor"></a>\[PR-MESSTRANSP\] Cybernetica AS. X-Road: Message Transport Protocol. Document ID: PR-MESSTRANSP.
+4.  <a id="Ref_PR-MESSTRANSP" class="anchor"></a>\[PR-MESSTRANSP\] Cybernetica AS. X-Road: Message Transport Protocol. Document ID: [PR-MESSTRANSP](../Protocols/pr-messtransp_x-road_message_transport_protocol_2.2_Y-743-4.docx).
 
-5.  <a id="Ref_UG-GCONF" class="anchor"></a>\[UG-GCONF\] Cybernetica AS. X-Road: Use Case Model for Global Configuration Distribution. Document ID: UG-GCONF.
+5.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] Cybernetica AS. X-Road: Use Case Model for Global Configuration Distribution. Document ID: [UC-GCONF](uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md).
 
-6.  <a id="Ref_UG-SYSPAR" class="anchor"></a>\[UG-SYSPAR\] Cybernetica AS. X-Road: System Parameters. Document ID: UG-SYSPAR.
+6.  <a id="Ref_UG-SYSPAR" class="anchor"></a>\[UG-SYSPAR\] Cybernetica AS. X-Road: System Parameters. Document ID: [UG-SYSPAR](../Manuals/ug-syspar_x-road_v6_system_parameters.md).
 
 7.  <a id="Ref_XAdES" class="anchor"></a>\[XAdES\] XML Advanced Electronic Signatures (XadES). ETSI TS 101 903 V1.3.2.
 
-8.  <a id="Ref_UC-SS" class="anchor"></a>\[UC-SS\] X-Road: Use Case Model for Security Server Management. Document ID: UC-SS.
+8.  <a id="Ref_UC-SS" class="anchor"></a>\[UC-SS\] X-Road: Use Case Model for Security Server Management. Document ID: [UC-SS](uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md).
 
-9.  <a id="Ref_UC-OPMON" class="anchor"></a>\[UC-OPMON\] Cybernetica AS. X-Road Operational Monitoring Daemon: Use Case Model. Document ID: UC-OPMON.
+9.  <a id="Ref_UC-OPMON" class="anchor"></a>\[UC-OPMON\] Cybernetica AS. X-Road Operational Monitoring Daemon: Use Case Model. Document ID: [UC-OPMON](../OperationalMonitoring/UseCases/uc-opmon_x-road_use_case_model_for_operational_monitoring_daemon_Y-1095-2.md).
 
+10. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Overview
 
 X-Road services are used by X-Road members communicating directly with each other via security servers, using synchronous request-response messaging pattern.
 
-Security servers periodically download global configuration from the central server (see \[[UG-GCONF](#Ref_UG-GCONF)\]). The global configuration is used to check validity of various data items, such as certificates, OCSP responses and timestamps. In addition, the global configuration is used to verify that communicating parties are registered on the X-Road.
+Security servers periodically download global configuration from the central server (see \[[UC-GCONF](#Ref_UC-GCONF)\]). The global configuration is used to check validity of various data items, such as certificates, OCSP responses and timestamps. In addition, the global configuration is used to verify that communicating parties are registered on the X-Road.
 
 Security servers ensure the integrity and confidentiality of the exchanged messages by signing the messages with the X-Road member's signing key and using mutually authenticated Transport Layer Security (TLS) channel for transport. The long-term evidential value of the signed messages is ensured by logging the exchanged messages and periodically timestamping the message logs.
 

--- a/doc/UseCases/uc-mess_x-road_member_communication_use_case_model.md
+++ b/doc/UseCases/uc-mess_x-road_member_communication_use_case_model.md
@@ -6,7 +6,7 @@
 
 **Analysis**
 
-Version: 1.7
+Version: 1.7  
 06.03.2018
 <!-- 38 pages -->
 Doc. ID: UC-MESS

--- a/doc/UseCases/uc-service_x-road_use_case_model_for_service_management_1.6_Y-883-3.md
+++ b/doc/UseCases/uc-service_x-road_use_case_model_for_service_management_1.6_Y-883-3.md
@@ -5,8 +5,8 @@
 # X-Road: Use Case Model for Service Management
 **Analysis**
 
-Version: 1.7
-29.08.2017
+Version: 1.8
+06.03.2018
 <!-- 45 pages -->
   
 Doc.ID: UC-SERVICE
@@ -32,6 +32,7 @@ Date       | Version | Description                                              
 23.12.2015 |  1.5    |   XTE-117 – WSDL validator (UC SERVICE\_08, UC SERVICE\_09, UC SERVICE\_14 updated; UC SERVICE\_44 added) | Meril Vaht
 29.12.2015 |  1.6    |   Editorial changes made | Meril Vaht
 29.08.2017 |  1.7    |  Changed documentation type from docx to md file |   Lasse Matikainen
+06.03.2018 |  1.8    |  Moved terms to term doc, added term doc reference and link, added internal MD-doc links | Tatu Repo
 
 <!-- toc -->
 
@@ -133,30 +134,23 @@ access rights required to carry out the use case.
 
 ### 1.2 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at
-<https://confluence.ria.ee/display/XROADDOCS/Terms%2C+definitions+and+abbrevations>.
-
-This section defines the terms that are not defined in the
-aforementioned document or that have contextual meaning specific to this
-document in addition to the general definition.
-
-**Service client** is an X-Road member, subsystem, local access rights
-group or global access rights group that has access rights to one or
-more services of a security server client.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
 1\. <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] X-Road 6. Central Server Installation
-Guide. Document ID: IG-CS.
+Guide. Document ID: [IG-CS](../Manuals/ig-cs_x-road_6_central_server_installation_guide.md).
 
 2\. <a id="Ref_IG-SS" class="anchor"></a>\[IG-SS\] X-Road 6. Security Server
-Installation Guide. Document ID: IG-SS.
+Installation Guide. Document ID: [IG-SS](../Manuals/ig-ss_x-road_v6_security_server_installation_guide.md).
 
 3\. <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] X-Road:
 Audit Log Events. Document ID: SPEC-AL.
 
 4\. <a id="Ref_UG-SYSPAR" class="anchor"></a>\[UG-SYSPAR\] X-Road:
-System Parameters. Document ID: UG-SYSPAR.
+System Parameters. Document ID: [UG-SYSPAR](../Manuals/ug-syspar_x-road_v6_system_parameters.md).
+
+5\. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Overview
 

--- a/doc/UseCases/uc-service_x-road_use_case_model_for_service_management_1.6_Y-883-3.md
+++ b/doc/UseCases/uc-service_x-road_use_case_model_for_service_management_1.6_Y-883-3.md
@@ -5,7 +5,7 @@
 # X-Road: Use Case Model for Service Management
 **Analysis**
 
-Version: 1.8
+Version: 1.8  
 06.03.2018
 <!-- 45 pages -->
   

--- a/doc/UseCases/uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md
+++ b/doc/UseCases/uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md
@@ -4,7 +4,7 @@
 # X-Road: Use Case Model for Security Server Management
 **Analysis**
 
-Version: 1.7
+Version: 1.7  
 06.03.2018
 <!-- 49 pages -->
 Doc. ID: UC-SS
@@ -132,7 +132,7 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 ### 1.3 References
 
 1.  <a id="Ref_IG-SS" class="anchor"></a>\[IG-SS\]
-    X-Road 6. Security Server Installation Guide. Document ID: IG-SS.
+    X-Road 6. Security Server Installation Guide. Document ID: [IG-SS](../Manuals/ig-ss_x-road_v6_security_server_installation_guide.md).
 
 2.  <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] X-Road:
     Audit Log Events. Document ID: SPEC-AL.
@@ -146,13 +146,13 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
     Profile, Internet Engineering Task Force, 2008.
 
 5.  <a id="Ref_UC-MESS" class="anchor"></a>\[UC-MESS\] X-Road: Use Case Model for
-    Member Communication. Document ID: UC-MESS.
+    Member Communication. Document ID: [UC-MESS](uc-mess_x-road_member_communication_use_case_model.md).
 
 6.  <a id="Ref_UC-MEMBER" class="anchor"></a>\[UC-MEMBER\] X-Road: Use Case Model for Member Management. Document
-    ID: UC-MEMBER.
+    ID: [UC-MEMBER](uc-member_x-road_use_case_model_for_member_management.md).
 
 7.  <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\]
-    X-Road: Protocol for Management Services. Document ID: PR-MSERV.
+    X-Road: Protocol for Management Services. Document ID: [PR-MSERV](../Protocols/pr-mserv_x-road_protocol_for_management_services.md).
 
 8. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 

--- a/doc/UseCases/uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md
+++ b/doc/UseCases/uc-ss_x-road_use_case_model_for_security_server_management_1.4_Y-883-4.md
@@ -4,8 +4,8 @@
 # X-Road: Use Case Model for Security Server Management
 **Analysis**
 
-Version: 1.6
-19.02.2018
+Version: 1.7
+06.03.2018
 <!-- 49 pages -->
 Doc. ID: UC-SS
 
@@ -29,6 +29,7 @@ Date       | Version | Description                                              
 16.12.2015 | 1.4     | UC SS\_18, UC SS\_19, UC SS\_20, UC SS\_29, UC SS\_30, UC SS\_31, UC SS\_34, UC SS\_35, UC SS\_38, UC SS\_39 updated. UC SS\_42 added. Editorial changes made. | Meril Vaht
 29.08.2017 | 1.5     | Changed documentation type from docx to md file |   Lasse Matikainen
 19.02.2018 | 1.6     | Updated the negative case extension for backing up the central server | Tatu Repo
+06.03.2018 | 1.7     | Moved terms to term doc, added term doc reference and link, added internal MD-doc links | Tatu Repo
 
 <!-- tocstop -->
 
@@ -126,20 +127,7 @@ the access rights required to carry out the use case.
 
 ### 1.2 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at
-<https://confluence.ria.ee/display/XROADDOCS/Terms%2C+definitions+and+abbrevations>.
-
-This section defines the terms that are not defined in the
-aforementioned document or that have contextual meaning specific to this
-document in addition to the general definition.
-
--   **Internal TLS key** and **internal** **TLS certificates** are used
-    for setting up the TLS connection between the security server and
-    the client information systems.
-
--   **Certificate signing request (CSR)** is generated in the security
-    server for a certain approved certification authority for signing a
-    public key and associated information.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.3 References
 
@@ -165,6 +153,8 @@ document in addition to the general definition.
 
 7.  <a id="Ref_PR-MSERV" class="anchor"></a>\[PR-MSERV\]
     X-Road: Protocol for Management Services. Document ID: PR-MSERV.
+
+8. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Overview
 

--- a/doc/UseCases/uc-trust_x-road_use_case_model_for_trust_service_management_1.1.1_Y-883-9.md
+++ b/doc/UseCases/uc-trust_x-road_use_case_model_for_trust_service_management_1.1.1_Y-883-9.md
@@ -4,8 +4,8 @@
 # X-Road: Use Case Model for Trust Service Management
 **Analysis**
 
-Version: 1.3
-06.03.2017
+Version: 1.3  
+06.03.2018
 <!-- 23 pages-->
 Doc. ID: UC-TRUST
 

--- a/doc/UseCases/uc-trust_x-road_use_case_model_for_trust_service_management_1.1.1_Y-883-9.md
+++ b/doc/UseCases/uc-trust_x-road_use_case_model_for_trust_service_management_1.1.1_Y-883-9.md
@@ -4,8 +4,8 @@
 # X-Road: Use Case Model for Trust Service Management
 **Analysis**
 
-Version: 1.2
-29.08.2017
+Version: 1.3
+06.03.2017
 <!-- 23 pages-->
 Doc. ID: UC-TRUST
 
@@ -22,6 +22,7 @@ Doc. ID: UC-TRUST
 25.10.2015   | 1.0     | Editorial changes made                                         | Riin Saarmäe
 04.11.2015   | 1.1     | UC TRUST\_19 added. Minor corrections made.                    | Riin Saarmäe
 29.08.2017   | 1.2     |  Changed documentation type from docx to md file |   Lasse Matikainen
+06.03.2018   | 1.3     | Moved terms to term doc, added term doc reference and link, added internal MD-doc links | Tatu Repo
 
 ## Table of Contents
 
@@ -81,39 +82,23 @@ the access rights required to carry out the use case.
 
 ### 1.1 Terms and Abbreviations
 
-The definitions for general X-Road terms can be found at
-<https://confluence.ria.ee/display/XROADDOCS/Terms%2C+definitions+and+abbrevations>.
-
-This section defines the terms that are not defined in the
-aforementioned document or that have contextual meaning specific to this
-document in addition to the general definition.
-
--   **Certification authority** (**CA**) is an entity that issues
-    digital certificates. A digital certificate certifies the ownership
-    of a public key by the named subject of the certificate.
-
--   **Certification service CA** is used in the X-Road system as a trust
-    anchor for a certification service. The certification service CA
-    may, but does not have to be a Root CA.
-
--   **Timestamping authority** (**TSA**) is an entity that issues
-    timestamps. Timestamps are used to prove the existence of certain
-    data before a certain point of time without the possibility that the
-    owner can backdate the timestamps.
+See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 1.2 References
 
-1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] X-Road 6. Central Server Installation Guide. Document ID: IG-CS.
+1.  <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] X-Road 6. Central Server Installation Guide. Document ID: [IG-CS](../Manuals/ig-cs_x-road_6_central_server_installation_guide.md).
 
 2.  <a id="Ref_SPEC-AL" class="anchor"></a>\[SPEC-AL\] Audit Log Events. Document ID: SPEC-AL.
 
-3.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] Global Configuration Distribution. Document ID: UC-GCONF.
+3.  <a id="Ref_UC-GCONF" class="anchor"></a>\[UC-GCONF\] Global Configuration Distribution. Document ID: [UC-GCONF](uc-gconf_x-road_use_case_model_for_global_configuration_distribution_1.4_Y-883-8.md).
 
-4.  <a id="Ref_UC-MESS" class="anchor"></a>\[UC-MESS\] Member Communication. Document ID: UC-MESS.
+4.  <a id="Ref_UC-MESS" class="anchor"></a>\[UC-MESS\] Member Communication. Document ID: [UC-MESS](uc-mess_x-road_member_communication_use_case_model.md).
 
 5.  <a id="Ref_X509" class="anchor"></a>\[X509\] Internet X.509 Public Key Infrastructure Certificate and Certificate
     Revocation List (CRL) Profile, Internet Engineering Task
     Force, 2008.
+
+6.  <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
 ## 2 Overview
 

--- a/doc/terms_x-road_docs.md
+++ b/doc/terms_x-road_docs.md
@@ -1,4 +1,6 @@
-# Terms of X-Road
+# X-Road Terms and Abbreviations
+
+Document ID: TA-TERMS
 
 ## Version history
 
@@ -7,6 +9,7 @@
  06.07.2015 | 0.1     | Initial draft                                                   |
  23.02.2017 | 0.2     | Converted to Github flavoured Markdown, added license text, adjusted tables and identification for better output in PDF. Added explanation of monitoring service | Toomas Mölder 
  14.11.2017 | 0.3     | All the descriptions in estonian language removed. Couple of new descriptions added | Antti Luoma
+ 06.03.2018 | 0.4     | Moved/merged terminology explanations from other X-Road repository MD-documents to this document | Tatu Repo |
 
 ## Table of Contents
 
@@ -29,7 +32,10 @@
     + [6.4.2 Subsystems and access rights](#642-subsystems-and-access-rights)
   * [6.5 X-Road protocols](#65-x-road-protocols)
   * [6.6 Logging and security](#66-logging-and-security)
-  * [6.7 Identificators and codes](#67-identificators-and-codes)
+  * [6.7 Identifiers and codes](#67-identifiers-and-codes)
+- [7 Technical terms](#7-technical-terms)
+  * [7.1 Technical terms](#71-technical-terms)
+  * [7.2 Technical terms](#72-technical-terms)
 
 <!-- tocstop -->
 
@@ -39,9 +45,9 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 ## 1 X-Road and X-Road Instance
 
-**X-Road instance** – legal, organizational and technical environment, enabling universal internet-based secure data exchange between the members of X-Road and limited to the participants administered by one governing authority.
+**X-Road instance** – a legal, organizational and technical environment, enabling universal internet-based secure data exchange between the members of X-Road and limited to the participants administered by one governing authority.
 
-**United/federated X-Road** – legal, organizational and technical environment, enabling universal internet-based secure data exchange between the members of united/federated X-Road instances
+**United/federated X-Road** – a legal, organizational and technical environment, enabling universal internet-based secure data exchange between the members of united/federated X-Road instances
 
 **Local X-Road instance** A group of members that are registered in a particular instance.
 
@@ -71,11 +77,23 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Authentication certificate of security server** – qualified certificate of e-stamp issued by certification service provider approved on X-Road and bound to security server, certifying authenticity of security server and used for authentication of security servers upon establishment of connection between security servers. Upon establishment of connection, it is checked from global configuration, if the security server trying to establish connection has registered the used authentication certificate in X-Road governing authority (i.e. the used authentication certificate is bound to the ID of security server).
 
+**Certification authority** (**CA**) – is an entity that issues digital certificates. A digital certificate certifies the ownership of a public key by the named subject of the certificate.
+
+**Certification service CA** – is used in the X-Road system as a trust anchor for a certification service. The certification service CA may, but does not have to be a Root CA.
+
+**Certificate signing request**  (**CSR**) – is generated in the security server for a certain approved certification authority for signing a public key and associated information.
+
 **Signature certificate of a member** – qualified certificate of e-stamp issued by certification service provider approved on X-Road and bound to a member, used for verification of the integrity of mediated messages and association of the member with the message.
 
-**Validation service** (OCSP) – Validation service of the validity of certificate issued by certification service provider approved on X-Road.
+**Validation service** (**OCSP**) – Validation service of the validity of certificate issued by certification service provider approved on X-Road.
 
 **Timestamp** – means data in electronic form which binds other data in electronic form to a particular time establishing evidence that the latter data existed at that time (EU No 910/2014)
+
+**Timestamping authority** (**TSA**) is an entity that issues timestamps. Timestamps are used to prove the existence of certain data before a certain point of time without the possibility that the owner can backdate the timestamps.
+
+**Internal TLS certificates** – are used for setting up the TLS connection between the security server and the client information systems.
+
+**TLS certificate** – is a certificate used by the security server to authenticate the information system when HTTPS protocol is used for connections between the service client's or service provider's security server and information system.
 
 ## 4 Roles of X-Road member
 
@@ -91,9 +109,9 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Security server owner** – a member responsible for security server and creation of a secure data exchange channel.
 
-**Security server client** – a member or subsystem of a member, whose relation with security server is registered in X-Road governing authority and who can use the security server on behalf of a member to exchange data on X-Road.
+**Security server client** – a member or a subsystem of a member, whose relation with the security server is registered in X-Road governing authority and who can use the security server on behalf of a member to exchange data on X-Road.
 
-**Security server host** – Member who provides security server hosting services to third parties and other members.
+**Security server host** – a member who provides security server hosting services to third parties and other members.
 
 ## 5 X-Road interfacing steps
 
@@ -121,9 +139,12 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Central components** are central server and configuration proxy.
 
-**Central server** – the component that manages all registrations of an local X-Road instance (security servers, members, subsystems). This global configuration is distributed for all the local and external security servers.  
+**Central server** – the component that manages all registrations of a local X-Road instance (security servers, members, subsystems). It is the primary configuration source in an X-Road system. Central server always manages an internal configuration source (i.e. configuration source distributing the internal configuration) and in addition, an external configuration source (i.e. configuration source distributing the external configuration) in case the X-Road system is federation-capable.  
 
-**Configuration proxy** acts as an intermediary between X-Road servers in the matters of global configuration exchange.
+**Configuration proxy** – an intermediary that may optionally be used to mediate configuration originating from the central server to the configuration clients. Configuration proxy manages configuration sources that are used to distribute configuration downloaded from other configuration sources.
+  - **Configuration proxy instance** – a process within the configuration proxy that deals with distributing the global configuration files of a specific X-Road instance.
+  
+**System configuration** –  consists of data stored in the database, and in the various configuration files held in the file system of an X-Road component.
 
 ### 6.3 X-Road external components
 
@@ -131,7 +152,14 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Information system** – a system including technological as well as organizational information processing of a member of X-Road. The information system (IS) uses and/or provides services via the X-Road.
 
-**Subsystem** – minimum part of information system of a member of X-Road, to which access to X-Road content service can be enabled. All the query's goes trough subsystem. 
+**Subsystem** – represents a part of an X-Road member's information system. X-Road members must declare parts of its information system as subsystems to use or provide X-Road services.
+
+-   The access rights of an X-Road members’ subsystems are independent – access rights given to one subsystem do not affect the access rights of the members’ other subsystems.
+
+-   Services provided by a subsystem are independent of the services provided by the members’ other subsystems.
+
+-   To sign the messages sent by a subsystem when using or providing X-Road services, the signing certificate of the member that manages the subsystem is used. An X-Road member can associate several different subsystems with one security server, and one subsystem can be associated with several security servers.
+ 
 
 ### 6.4 Elements of X-Road software
 
@@ -143,15 +171,21 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Metadata service** – services between members executed by X-Road governing authority, enabling members of X-Road to get an overview of X-Road (e.g. enabling to get an overview of completed services and access rights needed for the consumption of services). Generally, it shall meet the description of X-Road service.
 
-**Monitoring service** – The X-Road monitoring solution is conceptually split into two parts: environmental and operational monitoring. 
+**Monitoring services** – The X-Road monitoring solution is conceptually split into two parts: environmental and operational monitoring. 
 
-- **Environmental monitoring** is the monitoring of the X-Road environment: details of the security servers such as operating system, memory, disk space, CPU load, running processes and installed packages, etc.
+- **Environmental monitoring** – is the monitoring of the X-Road environment: details of the security servers such as operating system, memory, disk space, CPU load, running processes and installed packages, etc.
 
-- **Operational monitoring** is the monitoring of operational statistics such as which services have been called, how many times, what is the average response time, etc.
+- **Operational monitoring** – is the monitoring of operational statistics such as which services have been called, how many times, what is the average response time, etc.
+    + **Operational monitoring data** – contains operational data (such as which services have been called, how many times, what was the size of the response, etc.) of the X-Road security server(s).
+    + **Operational monitoring daemon** – collects and shares operational monitoring data of the X-Road security server(s), calculates and shares health data of the X-Road security server(s) that is based on collected operational monitoring data.
 
 **Management service** – services provided by the X-Road governing organization to manage security servers and security server clients. Management services are implemented as standard X-Road services following X-Road message protocol.
 
 **Message** – Data set meeting profile description and service description required by X-Road governing authority. Messages are divided into requests and responses. Message consists of headers and payload. Payload is a SOAP body that contains service specific content.
+
+**Service client** – is an X-Road member, subsystem, local access rights group or global access rights group that has access rights to one or more services of a security server client.
+
+**X-Road service** – SOAP-based web service that is offered by an X-Road member or by a subsystem and that can be used by other X-Road members or subsystems.
 
 #### 6.4.2 Subsystems and access rights
 
@@ -162,8 +196,6 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 **Global access right group** – access right group administered in the central server by the central server administrator, usable in the entire X-Road federation.
 
 **Local access right group** – access right group administered in security server by security server administrator, usable only in the specific security server within one security server client.
-
-**Global configuration** – a technical solution, through which X-Road governing authority regulates participants of X-Road. Global configuration includes XML-files, which are downloaded periodically from the central server of X-Road governing authority by security servers. Global configuration includes also following data: addresses and public keys of approved timestamp services; addresses and public keys of trust anchors (top CAs, timestamp services); public keys of intermediate CAs; addresses and public keys of OCSP services (if not available through the *Authority Information Access* extension of certificates); data of members of X-Road and their subsystems; addresses of registered security servers of members of X-Road; data of registered authentication certificates of security servers; registered clients of security servers; data of global access right groups.
 
 ### 6.5 X-Road protocols
 
@@ -183,11 +215,11 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **System service log** – a log which is made from a running system service of a security server, for example from xroad-confclient, -jetty, -proxy, signer services.  
 
-**Auditlog** log, where the user actions (through user interface), when the user changes the system state or configuration, are logged regardless of whether the outcome was a success or failure.
+**Audit log** log, where the user actions (through user interface), when the user changes the system state or configuration, are logged regardless of whether the outcome was a success or failure.
 
 **Batch signature** – e-stamp provided to a set of documents, enabling to separate a single document from the set and verify its signature.
 
-### 6.7 Identificators and codes
+### 6.7 Identifiers and codes
 
 **X-Road instance identifier** – identifier, that uniquely identifies the X-road instance in the X-Road Network.
 
@@ -195,11 +227,11 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Security server code** – identifier, that uniquely identifies the security server in all of the security servers of the security server owner.
 
-**Member class** – identifier, that is identified by X-Road governing authority and that uniquely identifies members with similar characteristics. Member class must assure the unique member code for each member in member class.
+**Member class** – identifier, that is identified by the X-Road governing authority and that uniquely identifies members with similar characteristics. All members with the same member class must be uniquely identifiable by their member codes.
 
-**Member code** – part of member identifier, that uniquely identifies X-Road member in its memberclass. Member code cannot change for the member.
+**Member code** – identifier, that uniquely identifies an X-Road member within its member class. The member code remains unchanged during the entire lifetime of the member.
 
-**Member identifier** – identifier, that uniquely identifies member in X-Road Network. Member identifier consists of X-Road instance identifier, member class and member code.
+**Member identifier** – identifier, that uniquely identifies a member in the X-Road Network. Member identifier consists of X-Road instance identifier, member class and member code.
 
 **Subsystem identifier** – identifier, that uniquely identifies subsystem in X-Road Network. Subsystem identifier consists of member identifier and subsystem code.
 
@@ -212,3 +244,98 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 **Global access group identifier** – identifier, that uniquely identifies access group in X-Road Network. Global access group identifier consists of X-Road instance identifier and global group code.
 
 **Local access group identifier** – identifier, that uniquely identifies access group for a security server client. Global access group identifier consists of X-Road instance identifier and global group code.
+
+### 6.8 Global configuration concepts
+
+**Configuration** – Set of parameters that are distributed by a configuration source. Configuration consists of one or more configuration parts that contain groups of related parameters.
+
+**Configuration Anchor** – is a set of information that can be used by configuration clients to access a configuration source and to verify the downloaded configuration. The configuration anchor is distributed as either a separate XML file in case the anchor points to a local configuration source or as a part of private parameters in case the anchor points to the configuration source managed by a federation partner.
+
+**Configuration Client** – is an entity that uses configuration anchor(s) for downloading configuration from configuration source(s). In an X-Roads system, security server and configuration proxy act as configuration clients. 
+
+**Configuration Provider** – is an entity responsible for maintaining and distributing global configuration. The configuration provider manages one or two configuration sources through which configuration is made available for configuration clients. In an X-Roads system, the central server and the configuration proxy act as configuration providers.
+
+**Configuration part (file)** – is an XML file containing system parameters.
+
+**Configuration Source** – is a component (HTTP server) managed by a configuration provider. The configuration distributed by the source can either be internal configuration or external configuration. The information needed to access and download configuration from a source is contained in the configuration anchor.
+
+**External configuration** – is distributed by a configuration source and only contains the shared parameters configuration part.
+
+**Global configuration** – a technical solution, through which X-Road governing authority regulates participants of X-Road. Global configuration consists of XML-files, which are downloaded periodically from the central server of X-Road governing authority by security servers. Global configuration includes following information:
+
+-   the addresses and public keys of trust anchors (certification service CAs and time stamping services);
+
+-   the public keys of intermediate CAs;
+
+-   the addresses and public keys of OCSP services (if not already available through the certificates' *Authority Information Access* extension);
+
+-   information about X-Road members and their subsystems;
+
+-   the addresses of the members' security servers registered in X-Road;
+
+-   information about the security servers' authentication certificates registered in X-Road;
+
+-   information about the security servers' clients registered in X-Road;
+
+-   information about global access rights groups;
+
+-   X-Road system parameters.  
+
+**Internal configuration** – is distributed by a configuration source and is composed of the following configuration parts: private parameters; shared parameters, and; optionally, other configuration parts that are specific to an X-Road instance – optional parameters.
+
+**Monitoring Parameters** – Set of parameters that control monitoring of security servers
+
+**Optional parameters** – is an optional configuration part that carries system parameters that have a contextual meaning only to a specific X-Road system installation.
+
+**Private parameters** – is a configuration part that holds system parameters that are only used by security servers that are part of the local X-Road system (i.e. the same X-Road system as the central server the configuration part originates from). In case of federated X-Road systems, the private parameters contain configuration anchors pointing to configuration sources distributing external configuration of federation partners.
+
+**Shared parameters** – is a configuration part that holds system parameters that are used both by the security servers of the local X-Road system and by the security servers belonging to X-Road systems federated with the local system.
+
+**Trusted anchor** – is a configuration anchor that points to the external configuration source of a federation partner and has been uploaded to the central server during the federation process. Trusted anchors are distributed to the configuration clients of the local X-Road system as a part of private parameters.
+
+
+## 7 Technical terms
+
+### 7.1 X-Road components
+
+### 7.2 Trust and security components
+
+**CA** - Certification Authority    
+
+**HSM** – Hardware security module
+
+**OCSP** – Online Certificate Status Protocol 
+
+**SSH** - Secure Shell
+
+**TLS** - Transport Layer Security
+
+**TSA** - Timestamping Authority 
+
+**TSP** - Time Stamp Provider
+
+### 7.3 General software terminology
+
+**CI** - Continuous Integration
+
+**DSL** - Domain Specific Language
+
+**HTTP** - Hypertext Transfer Protocol  
+
+**HTTPS** - Hypertext Transfer Protocol Secure
+
+**JMX** - The Java Management Extensions  
+  
+**JMXMP** - Java Management Extensions Messaging Protocol
+  
+**JSON** - JavaScript Object Notation  
+
+**MBean** - Java Managed Bean  
+
+**MIME** - Multipurpose Internet Mail Extensions
+
+**RPC** – Remote Procedure Call
+
+**SDK** - Software Development Kit
+
+**SOAP** - Simple Object Access Protocol  

--- a/doc/terms_x-road_docs.md
+++ b/doc/terms_x-road_docs.md
@@ -33,9 +33,10 @@ Document ID: TA-TERMS
   * [6.5 X-Road protocols](#65-x-road-protocols)
   * [6.6 Logging and security](#66-logging-and-security)
   * [6.7 Identifiers and codes](#67-identifiers-and-codes)
+  * [6.8 Global configuration concepts](#68-global-configuration-concepts)
 - [7 Technical terms](#7-technical-terms)
-  * [7.1 Technical terms](#71-technical-terms)
-  * [7.2 Technical terms](#72-technical-terms)
+  * [7.1 Trust and security terminology](#71-trust-and-security-terminology)
+  * [7.2 General software terminology](#72-general-software-terminology)
 
 <!-- tocstop -->
 
@@ -45,29 +46,29 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 ## 1 X-Road and X-Road Instance
 
-**X-Road instance** – a legal, organizational and technical environment, enabling universal internet-based secure data exchange between the members of X-Road and limited to the participants administered by one governing authority.
+**External X-Road instance** – an instance that has been federated with the local instance. For example the FI-instance is defined as an external instance in the EE's local point of view.
+
+**Local X-Road instance** – a group of members that are registered in a particular instance.
 
 **United/federated X-Road** – a legal, organizational and technical environment, enabling universal internet-based secure data exchange between the members of united/federated X-Road instances
 
-**Local X-Road instance** A group of members that are registered in a particular instance.
-
-**External X-Road instance** an instance that has been federated with the local instance. For example the FI-instance is defined as an external instance in the EE's local point of view.
+**X-Road instance** – a legal, organizational and technical environment, enabling universal internet-based secure data exchange between the members of X-Road and limited to the participants administered by one governing authority.
 
 ## 2 Participants of X-Road
 
-**X-Road governing authority** – authority, that sets the requirements for using X-road and establishing the procedure for using X-Road, managing and regulating participants of X-Road.
+**Approved trust service provider** – participant of X-Road, who meets the requirements established by X-Road governing authority and has passed the process of recognition of X-Road trust service provider.
 
-**X-Road Center** – participant of X-Road administering components of the X-Road software centre.
-
-**X-Road member / member** – participant of X-Road entitled to exchange data/messages on X-Road.
+**End user of dataservice** – information system, part of information system or physical person, who uses data service through the information system of X-Road member.
 
 **Local member** – a member entitled to exchange data/messages on the united X-Road and managed by governing authority of the local X-Road instance.
 
 **United / Federated member** – a member entitled to exchange data/messages on their behalf on the united X-Road, but managed by governing authority of the external X-Road instance.
 
-**End user of dataservice** – information system, part of information system or physical person, who uses data service through the information system of X-Road member.
+**X-Road Center** – participant of X-Road administering components of the X-Road software centre.
 
-**Approved trust service provider** – participant of X-Road, who meets the requirements established by X-Road governing authority and has passed the process of recognition of X-Road trust service provider.
+**X-Road governing authority** – authority, that sets the requirements for using X-road and establishing the procedure for using X-Road, managing and regulating participants of X-Road.
+
+**X-Road member / member** – participant of X-Road entitled to exchange data/messages on X-Road.
 
 ## 3 Trust services
 
@@ -83,47 +84,47 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Certificate signing request**  (**CSR**) – is generated in the security server for a certain approved certification authority for signing a public key and associated information.
 
-**Signature certificate of a member** – qualified certificate of e-stamp issued by certification service provider approved on X-Road and bound to a member, used for verification of the integrity of mediated messages and association of the member with the message.
+**Internal TLS certificates** – are used for setting up the TLS connection between the security server and the client information systems.
 
-**Validation service** (**OCSP**) – Validation service of the validity of certificate issued by certification service provider approved on X-Road.
+**Signature certificate of a member** – qualified certificate of e-stamp issued by certification service provider approved on X-Road and bound to a member, used for verification of the integrity of mediated messages and association of the member with the message.
 
 **Timestamp** – means data in electronic form which binds other data in electronic form to a particular time establishing evidence that the latter data existed at that time (EU No 910/2014)
 
-**Timestamping authority** (**TSA**) is an entity that issues timestamps. Timestamps are used to prove the existence of certain data before a certain point of time without the possibility that the owner can backdate the timestamps.
-
-**Internal TLS certificates** – are used for setting up the TLS connection between the security server and the client information systems.
+**Timestamping authority** (**TSA**) – is an entity that issues timestamps. Timestamps are used to prove the existence of certain data before a certain point of time without the possibility that the owner can backdate the timestamps.
 
 **TLS certificate** – is a certificate used by the security server to authenticate the information system when HTTPS protocol is used for connections between the service client's or service provider's security server and information system.
+
+**Validation service** (**OCSP**) – Validation service of the validity of certificate issued by certification service provider approved on X-Road.
 
 ## 4 Roles of X-Road member
 
 ### 4.1 In terms of dataservice
 
-**Dataservice provider** – member of X-Road responsible for dataservice provision, incl. granting the service SLA, managing the agreements with dataservice clients, granting access rights etc. Technically, dataservice provider is a party of interaction sending the response.
-
 **Dataservice client** – member of X-Road responsible for using the dataservice in accordance with dataservice usage agreements. Technically, dataservice client is a party of interaction sending the request.
 
 **Dataservice host** – A member enabling access to X-Road services through their information system (as the provider or user of the service) for natural or legal persons, who need not be members of X-Road.
 
-### 4.2 In terms of management of security server
+**Dataservice provider** – member of X-Road responsible for dataservice provision, incl. granting the service SLA, managing the agreements with dataservice clients, granting access rights etc. Technically, dataservice provider is a party of interaction sending the response.
 
-**Security server owner** – a member responsible for security server and creation of a secure data exchange channel.
+### 4.2 In terms of management of security server
 
 **Security server client** – a member or a subsystem of a member, whose relation with the security server is registered in X-Road governing authority and who can use the security server on behalf of a member to exchange data on X-Road.
 
 **Security server host** – a member who provides security server hosting services to third parties and other members.
 
+**Security server owner** – a member responsible for security server and creation of a secure data exchange channel.
+
 ## 5 X-Road interfacing steps
 
 **Affiliation of membership** – a process ending with becoming a member of X-Road. Becoming a member requires conclusion of affiliation contract and registration of data of the member (name and ID of the member) in X-Road central server. Requirements for affiliation are established by X-Road governing authority with relevant regulation/affiliation conditions
 
-**Registration of security server** – a process, where organizational and technical capacity of a member of X-Road is created to enable contacting the information system of the member of X-Road via X-Road. The result is a member of X-Road, with whom a secure data exchange channel of X-Road can be established. To ensure this, at least one security server shall be bound to the member in the central server.
-
-**Registration of subsystem** – a process for establishing organizational and technical capacity to distinguish organizational users or user groups on the level of a subsystem. Technically, subsystems shall be registered as security server clients.
-
 **Dataservice interfacing** – a process, where a member of X-Road creates organizational and technical capacity for offering or using dataservice. Interfacing includes development of the service by the member as well as its setup in security server, conclusion of service usage contracts and granting access rights. In order to use the service, service provider as well as service client shall undergo interfacing.
 
 **Interaction** – activation procedure of dataservice (single use), bilateral information exchange through dataservice, i.e. request of dataservice by the service client by sending a request, to which the service provider will send a response.
+
+**Registration of security server** – a process, where organizational and technical capacity of a member of X-Road is created to enable contacting the information system of the member of X-Road via X-Road. The result is a member of X-Road, with whom a secure data exchange channel of X-Road can be established. To ensure this, at least one security server shall be bound to the member in the central server.
+
+**Registration of subsystem** – a process for establishing organizational and technical capacity to distinguish organizational users or user groups on the level of a subsystem. Technically, subsystems shall be registered as security server clients.
 
 ## 6 Elements of X-Road technology
 
@@ -135,20 +136,20 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 ### 6.2 X-Road internal components
 
-**Security server** – standard software solution for using secure data exchange channel of X-Road and ensuring confidentiality, authenticity and integrity of messages/data exchanged on X-Road.
-
-**Central components** are central server and configuration proxy.
+**Central components** – are central server and configuration proxy.
 
 **Central server** – the component that manages all registrations of a local X-Road instance (security servers, members, subsystems). It is the primary configuration source in an X-Road system. Central server always manages an internal configuration source (i.e. configuration source distributing the internal configuration) and in addition, an external configuration source (i.e. configuration source distributing the external configuration) in case the X-Road system is federation-capable.  
 
 **Configuration proxy** – an intermediary that may optionally be used to mediate configuration originating from the central server to the configuration clients. Configuration proxy manages configuration sources that are used to distribute configuration downloaded from other configuration sources.
   - **Configuration proxy instance** – a process within the configuration proxy that deals with distributing the global configuration files of a specific X-Road instance.
+
+**Security server** – standard software solution for using secure data exchange channel of X-Road and ensuring confidentiality, authenticity and integrity of messages/data exchanged on X-Road.
   
 **System configuration** –  consists of data stored in the database, and in the various configuration files held in the file system of an X-Road component.
 
 ### 6.3 X-Road external components
 
-**Adapter Service** converts a request or response query (e.g. from REST) to required X-Road SOAP-protocol. 
+**Adapter Service** – converts a request or response query (e.g. from REST) to required X-Road SOAP-protocol. 
 
 **Information system** – a system including technological as well as organizational information processing of a member of X-Road. The information system (IS) uses and/or provides services via the X-Road.
 
@@ -165,9 +166,13 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 #### 6.4.1 Service and message
 
+**Central service** – dataservice, in case of which the name of service provider is defined by the governing authority. The reason for such alias-name may be the need to assure the service provision (when the service provider changes) without a need to change access rights.
+
 **Dataservice** – web-service executed by a member of X-Road, in order to enable access to the resources of information system of X-Road dataservice provider. The predefined request-response, sent by the information system of a member to the information system of another member and receiving agreed data in response.
 
-**Central service** – dataservice, in case of which the name of service provider is defined by the governing authority. The reason for such alias-name may be the need to assure the service provision (when the service provider changes) without a need to change access rights.
+**Management service** – services provided by the X-Road governing organization to manage security servers and security server clients. Management services are implemented as standard X-Road services following X-Road message protocol.
+
+**Message** – Data set meeting profile description and service description required by X-Road governing authority. Messages are divided into requests and responses. Message consists of headers and payload. Payload is a SOAP body that contains service specific content.
 
 **Metadata service** – services between members executed by X-Road governing authority, enabling members of X-Road to get an overview of X-Road (e.g. enabling to get an overview of completed services and access rights needed for the consumption of services). Generally, it shall meet the description of X-Road service.
 
@@ -179,17 +184,13 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
     + **Operational monitoring data** – contains operational data (such as which services have been called, how many times, what was the size of the response, etc.) of the X-Road security server(s).
     + **Operational monitoring daemon** – collects and shares operational monitoring data of the X-Road security server(s), calculates and shares health data of the X-Road security server(s) that is based on collected operational monitoring data.
 
-**Management service** – services provided by the X-Road governing organization to manage security servers and security server clients. Management services are implemented as standard X-Road services following X-Road message protocol.
-
-**Message** – Data set meeting profile description and service description required by X-Road governing authority. Messages are divided into requests and responses. Message consists of headers and payload. Payload is a SOAP body that contains service specific content.
-
 **Service client** – is an X-Road member, subsystem, local access rights group or global access rights group that has access rights to one or more services of a security server client.
 
 **X-Road service** – SOAP-based web service that is offered by an X-Road member or by a subsystem and that can be used by other X-Road members or subsystems.
 
 #### 6.4.2 Subsystems and access rights
 
-**Access right** in X-Road technology enables specifying the rights of security server clients (subsystems) to use dataservices.
+**Access right** – in X-Road technology enables specifying the rights of security server clients (subsystems) to use dataservices.
 
 **Access right group** – set of security server clients (subsystems), enabling to grant access rights to the entire group of subsystems and to delegate administration of access rights to the group administrator. Logical name can be assigned to an access right group.
 
@@ -199,33 +200,33 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 ### 6.5 X-Road protocols
 
-**Message Transport Protocol** – communications protocol that is used by service client's and service provider's security servers to exchange messages with each other.
-
-**Protocol for Downloading Configuration** – protocol that is used to distribute configuration to security servers of an X-Road instance.
-
 **Federation Protocol** – protocol that is used to distribute configuration between two federated X-Road instances.
 
 **Message protocol** – protocol that is used between information systems and security servers in the X-Road system.
+
+**Message Transport Protocol** – communications protocol that is used by service client's and service provider's security servers to exchange messages with each other.
+
+**Protocol for Downloading Configuration** – protocol that is used to distribute configuration to security servers of an X-Road instance.
 
 **Service Metadata Protocol** – protocol that describes methods that can be used by X-Road participants to discover what services are available to them and download the WSDL files describing these services.
 
 ### 6.6 Logging and security
 
+**Audit log** – log, where the user actions (through user interface), when the user changes the system state or configuration, are logged regardless of whether the outcome was a success or failure.
+
+**Batch signature** – e-stamp provided to a set of documents, enabling to separate a single document from the set and verify its signature.
+
 **Message log** – a log, where exchanged X-Road messages are logged and provided with batch signature. Records all regular messages passing through the security server into the database. The messages are stored together with their signatures and signatures are timestamped. The purpose of the message log is to provide means to prove the reception of a request/response message to a third party.
 
 **System service log** – a log which is made from a running system service of a security server, for example from xroad-confclient, -jetty, -proxy, signer services.  
 
-**Audit log** log, where the user actions (through user interface), when the user changes the system state or configuration, are logged regardless of whether the outcome was a success or failure.
-
-**Batch signature** – e-stamp provided to a set of documents, enabling to separate a single document from the set and verify its signature.
-
 ### 6.7 Identifiers and codes
 
-**X-Road instance identifier** – identifier, that uniquely identifies the X-road instance in the X-Road Network.
+**Central service identifier** – identifier, that uniquely identifies service in X-Road network without having a reference for service provider. Central service identifier consists of X-Road instance identifier and central service code.
 
-**Security server identifier** – identifier, that uniquely identifies security server in X-road Network. The security server identifier consists of security server owner identifier and security server code.
+**Global access group identifier** – identifier, that uniquely identifies access group in X-Road Network. Global access group identifier consists of X-Road instance identifier and global group code.
 
-**Security server code** – identifier, that uniquely identifies the security server in all of the security servers of the security server owner.
+**Local access group identifier** – identifier, that uniquely identifies access group for a security server client. Global access group identifier consists of X-Road instance identifier and global group code.
 
 **Member class** – identifier, that is identified by the X-Road governing authority and that uniquely identifies members with similar characteristics. All members with the same member class must be uniquely identifiable by their member codes.
 
@@ -233,17 +234,17 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Member identifier** – identifier, that uniquely identifies a member in the X-Road Network. Member identifier consists of X-Road instance identifier, member class and member code.
 
-**Subsystem identifier** – identifier, that uniquely identifies subsystem in X-Road Network. Subsystem identifier consists of member identifier and subsystem code.
+**Security server code** – identifier, that uniquely identifies the security server in all of the security servers of the security server owner.
 
-**Subsystem code** – code, that uniquely identifies subsystem in all of the subsystems of the member.
+**Security server identifier** – identifier, that uniquely identifies security server in X-road Network. The security server identifier consists of security server owner identifier and security server code.
 
 **Service identifier** – identifier, that uniquely identifies service in X-Road Network. The service identifier consists of member identifier of the service provider, service code and version of the service. Including version of the service in the service identifier is optional.
 
-**Central service identifier** – identifier, that uniquely identifies service in X-Road network without having a reference for service provider. Central service identifier consists of X-Road instance identifier and central service code.
+**Subsystem code** – code, that uniquely identifies subsystem in all of the subsystems of the member.
 
-**Global access group identifier** – identifier, that uniquely identifies access group in X-Road Network. Global access group identifier consists of X-Road instance identifier and global group code.
+**Subsystem identifier** – identifier, that uniquely identifies subsystem in X-Road Network. Subsystem identifier consists of member identifier and subsystem code.
 
-**Local access group identifier** – identifier, that uniquely identifies access group for a security server client. Global access group identifier consists of X-Road instance identifier and global group code.
+**X-Road instance identifier** – identifier, that uniquely identifies the X-road instance in the X-Road Network.
 
 ### 6.8 Global configuration concepts
 
@@ -253,9 +254,9 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Configuration Client** – is an entity that uses configuration anchor(s) for downloading configuration from configuration source(s). In an X-Roads system, security server and configuration proxy act as configuration clients. 
 
-**Configuration Provider** – is an entity responsible for maintaining and distributing global configuration. The configuration provider manages one or two configuration sources through which configuration is made available for configuration clients. In an X-Roads system, the central server and the configuration proxy act as configuration providers.
-
 **Configuration part (file)** – is an XML file containing system parameters.
+
+**Configuration Provider** – is an entity responsible for maintaining and distributing global configuration. The configuration provider manages one or two configuration sources through which configuration is made available for configuration clients. In an X-Roads system, the central server and the configuration proxy act as configuration providers.
 
 **Configuration Source** – is a component (HTTP server) managed by a configuration provider. The configuration distributed by the source can either be internal configuration or external configuration. The information needed to access and download configuration from a source is contained in the configuration anchor.
 
@@ -293,12 +294,9 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **Trusted anchor** – is a configuration anchor that points to the external configuration source of a federation partner and has been uploaded to the central server during the federation process. Trusted anchors are distributed to the configuration clients of the local X-Road system as a part of private parameters.
 
-
 ## 7 Technical terms
 
-### 7.1 X-Road components
-
-### 7.2 Trust and security components
+### 7.1 Trust and security terminology
 
 **CA** - Certification Authority    
 
@@ -314,7 +312,7 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 **TSP** - Time Stamp Provider
 
-### 7.3 General software terminology
+### 7.2 General software terminology
 
 **CI** - Continuous Integration
 


### PR DESCRIPTION
Includes:
- terms and abbreviation contents from individual documents merged into the terminology document
- other documents now link to the terminology document from their `Terms and abbreviations` sections.
- some basic fixes in the document structure to enable presenting terminology document references and links in a unified manner (toc, terms and references sections, relative document links, chapter and section numbering, etc.)
-  updated documentation index to include protocol extensions and opmonitoring documentation