### PR TITLE
PVAYLADEV-785

### DIFF
--- a/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
@@ -126,9 +126,16 @@ public class ConfigurationDirectoryV2 implements ConfigurationDirectory {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(path, Files::isDirectory)) {
             for (Path instanceDir : stream) {
                 log.trace("Loading parameters from {}", instanceDir);
-
-                loadPrivateParameters(instanceDir, privateParams);
-                loadSharedParameters(instanceDir, sharedParams);
+                try {
+                    loadPrivateParameters(instanceDir, privateParams);
+                } catch (Exception e) {
+                    log.error("Unable to load private parameters from {}", instanceDir);
+                }
+                try {
+                    loadSharedParameters(instanceDir, sharedParams);
+                } catch (Exception e) {
+                    log.error("Unable to load shared parameters from {}", instanceDir);
+                }
             }
         }
 

--- a/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
@@ -129,12 +129,12 @@ public class ConfigurationDirectoryV2 implements ConfigurationDirectory {
                 try {
                     loadPrivateParameters(instanceDir, privateParams);
                 } catch (Exception e) {
-                    log.error("Unable to load private parameters from {}", instanceDir);
+                    log.error("Unable to load private parameters from {}", instanceDir, e);
                 }
                 try {
                     loadSharedParameters(instanceDir, sharedParams);
                 } catch (Exception e) {
-                    log.error("Unable to load shared parameters from {}", instanceDir);
+                    log.error("Unable to load shared parameters from {}", instanceDir, e);
                 }
             }
         }

--- a/src/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryTest.java
+++ b/src/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryTest.java
@@ -91,8 +91,6 @@ public class ConfigurationDirectoryTest {
      */
     @Test
     public void readMalformedDirectoryV2() throws Exception {
-        thrown.expectError(X_MALFORMED_GLOBALCONF);
-
         ConfigurationDirectoryV2 dir = new ConfigurationDirectoryV2("src/test/resources/globalconf_malformed");
 
         assertNull(dir.getPrivate("foo"));

--- a/src/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConf.java
+++ b/src/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConf.java
@@ -186,12 +186,11 @@ public final class GlobalConf {
      * @return true if the global configuration is valid
      */
     public static boolean isValid() {
-        try {
-            return getInstance().isValid();
-        } catch (Exception e) {
-            log.error("Error in global configuration validation: {}", e);
+        GlobalConfProvider provider = getInstance();
+        if (provider == null) {
             return false;
         }
+        return provider.isValid();
     }
 
     /**

--- a/src/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConf.java
+++ b/src/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConf.java
@@ -186,9 +186,11 @@ public final class GlobalConf {
      * @return true if the global configuration is valid
      */
     public static boolean isValid() {
-
-        //TODO Null pointer exception if old global conf
-        return getInstance().isValid();
+        try {
+            return getInstance().isValid();
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**

--- a/src/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConf.java
+++ b/src/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConf.java
@@ -189,6 +189,7 @@ public final class GlobalConf {
         try {
             return getInstance().isValid();
         } catch (Exception e) {
+            log.error("Error in global configuration validation: {}", e);
             return false;
         }
     }


### PR DESCRIPTION
- Prettify error reporting in security server user interface when reading old (and thus malformed) global configuration
- Report proper reason instead of "Null pointer exception"

![pvayladev-785-malformed-global-conf](https://user-images.githubusercontent.com/582346/40308011-650384d2-5d0d-11e8-995f-bc38708e645d.png)
